### PR TITLE
Improved ToString() performance.

### DIFF
--- a/src/LightResults/Error.cs
+++ b/src/LightResults/Error.cs
@@ -11,7 +11,7 @@ namespace LightResults;
 public class Error : IError
 {
     internal static Error Empty { get; } = new();
-    
+
     /// <inheritdoc />
     public string Message { get; }
 
@@ -41,15 +41,10 @@ public class Error : IError
 #endif
     }
 
-    /// <summary>Initializes a new instance of the <see cref="Error" /> class with the specified metadata.</summary>
-    /// <param name="metadata">The metadata associated with the error.</param>
-    public Error((string Key, object Value) metadata) : this("", metadata)
-    {
-    }
 
     /// <summary>Initializes a new instance of the <see cref="Error" /> class with the specified metadata.</summary>
     /// <param name="metadata">The metadata associated with the error.</param>
-    public Error(IDictionary<string, object> metadata) : this("", metadata)
+    public Error((string Key, object Value) metadata) : this("", metadata)
     {
     }
 
@@ -67,6 +62,12 @@ public class Error : IError
         builder.Add(metadata.Key, metadata.Value);
         _metadata = builder.ToImmutable();
 #endif
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="Error" /> class with the specified metadata.</summary>
+    /// <param name="metadata">The metadata associated with the error.</param>
+    public Error(IDictionary<string, object> metadata) : this("", metadata)
+    {
     }
 
     /// <summary>Initializes a new instance of the <see cref="Error" /> class with the specified error message and metadata.</summary>

--- a/tools/LightResults.CurrentBenchmarks/Benchmarks.cs
+++ b/tools/LightResults.CurrentBenchmarks/Benchmarks.cs
@@ -1,76 +1,153 @@
 ﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Jobs;
+using LightResults.Common;
 
 namespace LightResults.CurrentBenchmarks;
 
 [MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+[HideColumns(Column.Job, Column.Iterations, Column.Error, Column.StdDev, Column.Gen0, Column.Gen1, Column.Gen2)]
 public class Benchmarks
 {
-    private const int ResultValue = 0;
-    private const string ErrorMessage = "An unknown error occured.";
-    private static readonly Error Error = new(ErrorMessage);
-    private static readonly Result FailedResult = Result.Fail(Error);
-    
     [Params(100_000)]
     public int Iterations { get; set; }
 
+    private const int ResultValue = 0;
+    private const string ErrorMessage = "An unknown error occured.";
+    private static readonly Error ErrorWithMessage = new(ErrorMessage);
+    private static readonly Result ResultOk = Result.Ok();
+    private static readonly Result ResultFail = Result.Fail();
+    private static readonly Result ResultFailWithMessage = Result.Fail(ErrorWithMessage);
+    private static readonly Result<int> ResultTValueOk = Result<int>.Ok(ResultValue);
+    private static readonly Result<int> ResultTValueFail = Result<int>.Fail();
+    private static readonly Result<int> ResultTValueFailWithMessage = Result<int>.Fail(ErrorWithMessage);
+    private static readonly CustomResult CustomResultOk = CustomResult.Ok();
+    private static readonly CustomResult CustomResultFail = CustomResult.Fail();
+    private static readonly CustomResult CustomResultFailWithMessage = CustomResult.Fail(ErrorWithMessage);
+
     [Benchmark]
-    public void Current_ResultBaseIndexer()
+    public void Develop_ResultBaseIndexer()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
-            _ = FailedResult.Errors[0];
+            _ = ResultFailWithMessage.Errors[0];
     }
 
     [Benchmark]
-    public void Current_ResultBaseHasError()
+    public void Develop_ResultBaseHasError()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
-            _ = FailedResult.HasError<Error>();
+            _ = ResultFailWithMessage.HasError<Error>();
     }
 
     [Benchmark]
-    public void Current_ResultOk()
+    public void Develop_ResultOkToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = ResultOk.ToString();
+    }
+
+    [Benchmark]
+    public void Develop_ResultFailToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = ResultFail.ToString();
+    }
+
+    [Benchmark]
+    public void Develop_ResultFailWithMessageToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = ResultFailWithMessage.ToString();
+    }
+
+    [Benchmark]
+    public void Develop_ResultTValueOkToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = ResultTValueOk.ToString();
+    }
+
+    [Benchmark]
+    public void Develop_ResultTValueFailToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = ResultTValueFail.ToString();
+    }
+
+
+    [Benchmark]
+    public void Develop_ResultTValueFailWithMessageToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = ResultTValueFailWithMessage.ToString();
+    }
+
+    [Benchmark]
+    public void Develop_CustomResultOkToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = CustomResultOk.ToString();
+    }
+
+    [Benchmark]
+    public void Develop_CustomResultFailToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = CustomResultFail.ToString();
+    }
+
+    [Benchmark]
+    public void Develop_CustomResultFailWithMessageToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = CustomResultFailWithMessage.ToString();
+    }
+
+    [Benchmark]
+    public void Develop_ResultOk()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
             _ = Result.Ok();
     }
 
     [Benchmark]
-    public void Current_ResultFail()
+    public void Develop_ResultFail()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
             _ = Result.Fail();
     }
 
     [Benchmark]
-    public void Current_ResultFailWithError()
+    public void Develop_ResultFailWithError()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
-            _ = Result.Fail(Error);
+            _ = Result.Fail(ErrorWithMessage);
     }
 
     [Benchmark]
-    public void Current_ResultTValueOk()
+    public void Develop_ResultTValueOk()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
             _ = Result<int>.Ok(ResultValue);
     }
 
     [Benchmark]
-    public void Current_ResultTValueFail()
+    public void Develop_ResultTValueFail()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
             _ = Result<int>.Fail();
     }
 
     [Benchmark]
-    public void Current_ResultTValueFailWithError()
+    public void Develop_ResultTValueFailWithError()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
-            _ = Result<int>.Fail(Error);
+            _ = Result<int>.Fail(ErrorWithMessage);
     }
 
     [Benchmark]
-    public void Current_ResultOkTValue()
+    public void Develop_ResultOkTValue()
     {
         // ReSharper disable once RedundantTypeArgumentsOfMethod
         for (var iteration = 0; iteration < Iterations; iteration++)
@@ -78,30 +155,56 @@ public class Benchmarks
     }
 
     [Benchmark]
-    public void Current_ResultFailTValue()
+    public void Develop_ResultFailTValue()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
             _ = Result.Fail<int>();
     }
 
     [Benchmark]
-    public void Current_ResultFailWithErrorTValue()
+    public void Develop_ResultFailWithErrorTValue()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
-            _ = Result.Fail<int>(Error);
+            _ = Result.Fail<int>(ErrorWithMessage);
     }
 
     [Benchmark]
-    public void Current_NewError()
+    public void Develop_NewError()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
             _ = new Error();
     }
 
     [Benchmark]
-    public void Current_NewErrorWithString()
+    public void Develop_NewErrorWithString()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
             _ = new Error(ErrorMessage);
+    }
+
+    private sealed class CustomResult : ResultBase
+    {
+        private CustomResult()
+        {
+        }
+
+        private CustomResult(IError error) : base(error)
+        {
+        }
+
+        public static CustomResult Ok()
+        {
+            return new CustomResult();
+        }
+
+        public static CustomResult Fail()
+        {
+            return new CustomResult(new Error());
+        }
+
+        public static CustomResult Fail(IError error)
+        {
+            return new CustomResult(error);
+        }
     }
 }

--- a/tools/LightResults.DevelopBenchmarks/Benchmarks.cs
+++ b/tools/LightResults.DevelopBenchmarks/Benchmarks.cs
@@ -1,31 +1,107 @@
-﻿using System.Collections.Immutable;
-using BenchmarkDotNet.Attributes;
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Jobs;
+using LightResults.Common;
 
 namespace LightResults.DevelopBenchmarks;
 
 [MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+[HideColumns(Column.Job, Column.Iterations, Column.Error, Column.StdDev, Column.Gen0, Column.Gen1, Column.Gen2)]
 public class Benchmarks
 {
-    private const int ResultValue = 0;
-    private const string ErrorMessage = "An unknown error occured.";
-    private static readonly Error Error = new(ErrorMessage);
-    private static readonly Result FailedResult = Result.Fail(Error);
-    
     [Params(100_000)]
     public int Iterations { get; set; }
+
+    private const int ResultValue = 0;
+    private const string ErrorMessage = "An unknown error occured.";
+    private static readonly Error ErrorWithMessage = new(ErrorMessage);
+    private static readonly Result ResultOk = Result.Ok();
+    private static readonly Result ResultFail = Result.Fail();
+    private static readonly Result ResultFailWithMessage = Result.Fail(ErrorWithMessage);
+    private static readonly Result<int> ResultTValueOk = Result<int>.Ok(ResultValue);
+    private static readonly Result<int> ResultTValueFail = Result<int>.Fail();
+    private static readonly Result<int> ResultTValueFailWithMessage = Result<int>.Fail(ErrorWithMessage);
+    private static readonly CustomResult CustomResultOk = CustomResult.Ok();
+    private static readonly CustomResult CustomResultFail = CustomResult.Fail();
+    private static readonly CustomResult CustomResultFailWithMessage = CustomResult.Fail(ErrorWithMessage);
 
     [Benchmark]
     public void Develop_ResultBaseIndexer()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
-            _ = FailedResult.Errors[0];
+            _ = ResultFailWithMessage.Errors[0];
     }
 
     [Benchmark]
     public void Develop_ResultBaseHasError()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
-            _ = FailedResult.HasError<Error>();
+            _ = ResultFailWithMessage.HasError<Error>();
+    }
+
+    [Benchmark]
+    public void Develop_ResultOkToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = ResultOk.ToString();
+    }
+
+    [Benchmark]
+    public void Develop_ResultFailToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = ResultFail.ToString();
+    }
+
+    [Benchmark]
+    public void Develop_ResultFailWithMessageToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = ResultFailWithMessage.ToString();
+    }
+
+    [Benchmark]
+    public void Develop_ResultTValueOkToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = ResultTValueOk.ToString();
+    }
+
+    [Benchmark]
+    public void Develop_ResultTValueFailToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = ResultTValueFail.ToString();
+    }
+
+
+    [Benchmark]
+    public void Develop_ResultTValueFailWithMessageToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = ResultTValueFailWithMessage.ToString();
+    }
+
+    [Benchmark]
+    public void Develop_CustomResultOkToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = CustomResultOk.ToString();
+    }
+
+    [Benchmark]
+    public void Develop_CustomResultFailToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = CustomResultFail.ToString();
+    }
+
+    [Benchmark]
+    public void Develop_CustomResultFailWithMessageToString()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = CustomResultFailWithMessage.ToString();
     }
 
     [Benchmark]
@@ -46,7 +122,7 @@ public class Benchmarks
     public void Develop_ResultFailWithError()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
-            _ = Result.Fail(Error);
+            _ = Result.Fail(ErrorWithMessage);
     }
 
     [Benchmark]
@@ -67,7 +143,7 @@ public class Benchmarks
     public void Develop_ResultTValueFailWithError()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
-            _ = Result<int>.Fail(Error);
+            _ = Result<int>.Fail(ErrorWithMessage);
     }
 
     [Benchmark]
@@ -89,7 +165,7 @@ public class Benchmarks
     public void Develop_ResultFailWithErrorTValue()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
-            _ = Result.Fail<int>(Error);
+            _ = Result.Fail<int>(ErrorWithMessage);
     }
 
     [Benchmark]
@@ -104,5 +180,31 @@ public class Benchmarks
     {
         for (var iteration = 0; iteration < Iterations; iteration++)
             _ = new Error(ErrorMessage);
+    }
+
+    private sealed class CustomResult : ResultBase
+    {
+        private CustomResult()
+        {
+        }
+
+        private CustomResult(IError error) : base(error)
+        {
+        }
+
+        public static CustomResult Ok()
+        {
+            return new CustomResult();
+        }
+
+        public static CustomResult Fail()
+        {
+            return new CustomResult(new Error());
+        }
+
+        public static CustomResult Fail(IError error)
+        {
+            return new CustomResult(error);
+        }
     }
 }


### PR DESCRIPTION
```
BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.3155/23H2/2023Update/SunValley3)
13th Gen Intel Core i7-13700KF, 1 CPU, 24 logical and 16 physical cores
.NET SDK 8.0.200
  [Host]   : .NET 8.0.2 (8.0.224.6711), X64 RyuJIT AVX2
  .NET 8.0 : .NET 8.0.2 (8.0.224.6711), X64 RyuJIT AVX2
Iterations : 100 000
```
| Method                              |      Before |       After |     Before |      After |
|-------------------------------------|------------:|------------:|-----------:|-----------:|
| ResultBaseIndexer                   |    26.06 us |    26.33 us |          - |          - |
| ResultBaseHasError                  |    89.81 us |    90.63 us |          - |          - |
| ResultOkToString                    | 3,043.52 us |    27.78 us | 28800370 B |          - |
| ResultFailToString                  | 3,232.66 us |    74.86 us | 28800370 B |          - |
| ResultFailWithMessageToString       | 6,744.95 us | 2,837.31 us | 69600892 B | 24800002 B |
| ResultTValueOkToString              | 4,398.32 us | 2,556.12 us | 47200003 B | 15200002 B |
| ResultTValueFailToString            | 2,601.94 us |    74.39 us | 28800002 B |          - |
| ResultTValueFailWithMessageToString | 6,339.77 us | 2,743.11 us | 69600003 B | 24800002 B |
| CustomResultOkToString              | 4,409.29 us | 1,880.67 us | 43200577 B |  8800118 B |
| CustomResultFailToString            | 4,529.00 us | 2,220.69 us | 44000588 B |  9600129 B |
| CustomResultFailWithMessageToString | 6,743.94 us | 2,797.87 us | 71200949 B | 26400352 B |
| ResultOk                            |    18.76 us |    18.75 us |          - |          - |
| ResultFail                          |    18.77 us |    18.78 us |          - |          - |
| ResultFailWithError                 |   535.57 us |   540.72 us |  8000000 B |  8000000 B |
| ResultTValueOk                      |   191.08 us |   193.06 us |  3200000 B |  3200000 B |
| ResultTValueFail                    |    18.75 us |    18.73 us |          - |          - |
| ResultTValueFailWithError           |   549.88 us |   551.19 us |  8800000 B |  8800000 B |
| ResultOkTValue                      |   191.63 us |   190.97 us |  3200000 B |  3200000 B |
| ResultFailTValue                    |    18.75 us |    18.74 us |          - |          - |
| ResultFailWithErrorTValue           |   556.70 us |   548.32 us |  8800000 B |  8800000 B |
| NewError                            |   223.62 us |   222.60 us |  3200000 B |  3200000 B |
| NewErrorWithString                  |   222.42 us |   222.99 us |  3200000 B |  3200000 B |