### PR TITLE
Add `HasError<T>(out T error)` method

### DIFF
--- a/src/LightResults/IResult.cs
+++ b/src/LightResults/IResult.cs
@@ -27,4 +27,11 @@ public interface IResult
     /// <returns><c>true</c> if an error of the specified type is present; otherwise, <c>false</c>.</returns>
     bool HasError<TError>()
         where TError : IError;
+
+    /// <summary>Checks if the result contains an error of the specific type.</summary>
+    /// <param name="error">The error with the specified type.</param>
+    /// <typeparam name="TError">The type of error to check for.</typeparam>
+    /// <returns><c>true</c> if an error of the specified type is present; otherwise, <c>false</c></returns>
+    bool HasError<TError>([MaybeNullWhen(false)] out TError error)
+        where TError : IError;
 }

--- a/src/LightResults/Result.Errors.cs
+++ b/src/LightResults/Result.Errors.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace LightResults;
 
 partial struct Result
@@ -36,5 +38,41 @@ partial struct Result
             }
 
         return typeof(TError) == typeof(Error);
+    }
+
+    /// <inheritdoc/>
+    public bool HasError<TError>([MaybeNullWhen(false)] out TError error)
+        where TError : IError
+    {
+        if (_isSuccess)
+        {
+            error = default;
+            return false;
+        }
+
+        if (_errors.HasValue)
+        {
+            // Do not convert to LINQ, this creates unnecessary heap allocations.
+            // For is the most efficient way to loop. It is the fastest and does not allocate.
+            // ReSharper disable once ForCanBeConvertedToForeach
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            for (var index = 0; index < _errors.Value.Length; index++)
+            {
+                if (_errors.Value[index] is not TError)
+                    continue;
+
+                error = (TError)_errors.Value[index];
+                return true;
+            }
+        }
+
+        if (typeof(TError) == typeof(Error))
+        {
+            error = (TError)Error.Empty;
+            return true;
+        }
+
+        error = default;
+        return false;
     }
 }

--- a/src/LightResults/Result`1.Errors.cs
+++ b/src/LightResults/Result`1.Errors.cs
@@ -1,4 +1,6 @@
-﻿namespace LightResults;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace LightResults;
 
 partial struct Result<TValue>
 {
@@ -36,5 +38,41 @@ partial struct Result<TValue>
             }
 
         return typeof(TError) == typeof(Error);
+    }
+
+    /// <inheritdoc/>
+    public bool HasError<TError>([MaybeNullWhen(false)] out TError error)
+        where TError : IError
+    {
+        if (_isSuccess)
+        {
+            error = default;
+            return false;
+        }
+
+        if (_errors.HasValue)
+        {
+            // Do not convert to LINQ, this creates unnecessary heap allocations.
+            // For is the most efficient way to loop. It is the fastest and does not allocate.
+            // ReSharper disable once ForCanBeConvertedToForeach
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            for (var index = 0; index < _errors.Value.Length; index++)
+            {
+                if (_errors.Value[index] is not TError)
+                    continue;
+
+                error = (TError)_errors.Value[index];
+                return true;
+            }
+        }
+
+        if (typeof(TError) == typeof(Error))
+        {
+            error = (TError)Error.Empty;
+            return true;
+        }
+
+        error = default;
+        return false;
     }
 }

--- a/tests/LightResults.Tests/ResultTValueTests.cs
+++ b/tests/LightResults.Tests/ResultTValueTests.cs
@@ -28,7 +28,11 @@ public sealed class ResultTValueTests
             resultError.Should().Be(Error.Empty);
             result.Errors.Should().ContainSingle().Which.Should().BeOfType<Error>();
             result.HasError<Error>().Should().BeTrue();
+            result.HasError<Error>(out var error).Should().BeTrue();
+            error.Should().Be(Error.Empty);
             result.HasError<ValidationError>().Should().BeFalse();
+            result.HasError<ValidationError>(out var validationError).Should().BeFalse();
+            validationError.Should().Be(default);
         }
     }
 
@@ -49,7 +53,11 @@ public sealed class ResultTValueTests
             resultError.Should().Be(Error.Empty);
             result.Errors.Should().ContainSingle().Which.Should().BeOfType<Error>();
             result.HasError<Error>().Should().BeTrue();
+            result.HasError<Error>(out var error).Should().BeTrue();
+            error.Should().Be(Error.Empty);
             result.HasError<ValidationError>().Should().BeFalse();
+            result.HasError<ValidationError>(out var validationError).Should().BeFalse();
+            validationError.Should().Be(default);
         }
     }
 
@@ -468,6 +476,25 @@ public sealed class ResultTValueTests
     }
 
     [Fact]
+    public void HasError_WithMatchingErrorType_ShouldOutFirstMatch()
+    {
+        // Arrange
+        var firstError = new ValidationError("Validation error");
+        var errors = new List<IError> { firstError, new ValidationError("Error 2") };
+        var result = Result.Fail<int>(errors);
+
+        // Act
+        var hasError = result.HasError<ValidationError>(out var error);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            hasError.Should().BeTrue();
+            error.Should().Be(firstError);
+        }
+    }
+
+    [Fact]
     public void HasError_WithNonMatchingErrorType_ShouldReturnFalse()
     {
         // Arrange
@@ -478,6 +505,23 @@ public sealed class ResultTValueTests
     }
 
     [Fact]
+    public void HasError_WithNonMatchingErrorType_ShouldOutDefaultError()
+    {
+        // Arrange
+        var result = Result.Fail<int>(new Error("Generic error"));
+
+        // Act
+        var hasError = result.HasError<ValidationError>(out var error);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            hasError.Should().BeFalse();
+            error.Should().Be(default);
+        }
+    }
+
+    [Fact]
     public void HasError_WhenIsSuccess_ShouldReturnFalse()
     {
         // Arrange
@@ -485,6 +529,23 @@ public sealed class ResultTValueTests
 
         // Assert
         result.HasError<ValidationError>().Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasError_WhenIsSuccess_ShouldOutDefaultError()
+    {
+        // Arrange
+        var result = Result.Ok(42);
+
+        // Act
+        var hasError = result.HasError<ValidationError>(out var error);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            hasError.Should().BeFalse();
+            error.Should().Be(default);
+        }
     }
 
     [Fact]

--- a/tests/LightResults.Tests/ResultTests.cs
+++ b/tests/LightResults.Tests/ResultTests.cs
@@ -22,7 +22,11 @@ public sealed class ResultTests
             result.Errors.Should().ContainSingle();
             result.Errors.First().Should().BeOfType<Error>();
             result.HasError<Error>().Should().BeTrue();
+            result.HasError<Error>(out var error).Should().BeTrue();
+            error.Should().Be(Error.Empty);
             result.HasError<ValidationError>().Should().BeFalse();
+            result.HasError<ValidationError>(out var validationError).Should().BeFalse();
+            validationError.Should().Be(default);
         }
     }
 
@@ -389,6 +393,25 @@ public sealed class ResultTests
     }
 
     [Fact]
+    public void HasError_WithMatchingErrorType_ShouldOutFirstMatch()
+    {
+        // Arrange
+        var firstError = new ValidationError("Validation error");
+        var errors = new List<IError> { firstError, new ValidationError("Validation error 2") };
+        var result = Result.Fail(errors);
+
+        // Act
+        var hasError = result.HasError<ValidationError>(out var error);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            hasError.Should().BeTrue();
+            error.Should().Be(firstError);
+        }
+    }
+
+    [Fact]
     public void HasError_WithNonMatchingErrorType_ShouldReturnFalse()
     {
         // Arrange
@@ -399,6 +422,23 @@ public sealed class ResultTests
     }
 
     [Fact]
+    public void HasError_WithNonMatchingErrorType_ShouldOutDefaultError()
+    {
+        // Arrange
+        var result = Result.Fail(new Error("Generic error"));
+
+        // Act
+        var hasError = result.HasError<ValidationError>(out var error);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            hasError.Should().BeFalse();
+            error.Should().Be(default);
+        }
+    }
+
+    [Fact]
     public void HasError_WhenIsSuccess_ShouldReturnFalse()
     {
         // Arrange
@@ -406,6 +446,23 @@ public sealed class ResultTests
 
         // Assert
         result.HasError<ValidationError>().Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasError_WhenIsSuccess_ShouldOutDefaultError()
+    {
+        // Arrange
+        var result = Result.Ok();
+
+        // Act
+        var hasError = result.HasError<ValidationError>(out var error);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            hasError.Should().BeFalse();
+            error.Should().Be(default);
+        }
     }
 
     [Fact]

--- a/tools/LightResults.DevelopBenchmarks/Benchmarks.cs
+++ b/tools/LightResults.DevelopBenchmarks/Benchmarks.cs
@@ -117,6 +117,13 @@ public class Benchmarks
     }
 
     [Benchmark]
+    public void Develop_Result_HasError_Out()
+    {
+        for (var iteration = 0; iteration < Iterations; iteration++)
+            _ = ResultFailWithErrorMessage.HasError<Error>(out _);
+    }
+
+    [Benchmark]
     public void Develop_Result_Error()
     {
         for (var iteration = 0; iteration < Iterations; iteration++)


### PR DESCRIPTION
## What's the change?
Adding an overload method for `HasError<T>()` which has an `out` parameter, so that users can easily get the first instance of an error with the specified type on a Result. Example:

```cs
var result = ProcessRequest();
if (result.HasError<ValidationError>(out var error)
{
    var details = new ValidationProblemDetails(error.validationProblems);
    return ValidationProblem(details);
}
```

## How is it implemented?
Largely the same as the existing `HasError<T>()` implementation with the `for` loop, but it also gets a reference to the error at the index that matches. If `_errors` is null and the specified type is `Error`, it returns `true` and outputs an empty error like `IsFailed(out IError error)` does. Otherwise it returns false.

The existing tests for default structs have been updated to test the new method, and extra bespoke tests were added for it too.

I've also added a benchmark test, but didn't update the Working.md file so you can run it on the same machine as the current results. On my machine the new method was 4ns slower than the normal HasError method.