### PR TITLE
discriminated union like api

### DIFF
--- a/src/LightResults/IResult.cs
+++ b/src/LightResults/IResult.cs
@@ -34,4 +34,38 @@ public interface IResult
     /// <returns><c>true</c> if an error of the specified type exists; otherwise, <c>false</c>.</returns>
     bool HasError<TError>([MaybeNullWhen(false)] out TError error)
         where TError : IError;
+
+    /// <summary>
+    /// Evaluate the result in style of a discriminated union.
+    /// </summary>
+    /// <param name="onSuccess">Invoked when result is a success</param>
+    /// <param name="onError">Invoked when result is a failure</param>
+    void Switch(Action onSuccess, Action<IError> onError);
+    
+    /// <summary>
+    /// Evaluate the result in style of a discriminated union.
+    /// </summary>
+    /// <param name="onSuccess">Invoked when result is a success</param>
+    /// <param name="onError">Invoked when result is a failure</param>
+    /// <returns>A task for the async operation</returns>
+    Task SwitchAsync(Func<Task> onSuccess, Func<IError, Task> onError);
+    
+    /// <summary>
+    /// Evaluate the result in style of a discriminated union. A result must be returned
+    /// </summary>
+    /// <param name="onSuccess">Invoked when result is a success</param>
+    /// <param name="onError">Invoked when result is a failure</param>
+    /// <typeparam name="TReturn">Type to be returned</typeparam>
+    /// <returns>The result of the operation</returns>
+    TReturn Match<TReturn>(Func<TReturn> onSuccess, Func<IError, TReturn> onError);
+
+    /// <summary>
+    /// Evaluate the result in style of a discriminated union. A result must be returned
+    /// </summary>
+    /// <param name="onSuccess">Invoked when result is a success</param>
+    /// <param name="onError">Invoked when result is a failure</param>
+    /// <typeparam name="TReturn">Type to be returned</typeparam>
+    /// <returns>The result of the operation</returns>
+    Task<TReturn> MatchAsync<TReturn>(Func<Task<TReturn>> onSuccess, 
+        Func<IError, Task<TReturn>> onError);
 }

--- a/src/LightResults/IResult`1.cs
+++ b/src/LightResults/IResult`1.cs
@@ -22,4 +22,38 @@ public interface IResult<TValue> : IResult
     /// <param name="value">The value of the result.</param>
     /// <returns><c>true</c> if the result failure; otherwise, <c>false</c>.</returns>
     bool IsFailure([MaybeNullWhen(false)] out IError error, [MaybeNullWhen(true)] out TValue value);
+
+    /// <summary>
+    /// Evaluate the result in style of a discriminated union.
+    /// </summary>
+    /// <param name="onSuccess">Invoked when result is a success</param>
+    /// <param name="onError">Invoked when result is a failure</param>
+    void Switch(Action<TValue> onSuccess, Action<IError> onError);
+    
+    /// <summary>
+    /// Evaluate the result in style of a discriminated union.
+    /// </summary>
+    /// <param name="onSuccess">Invoked when result is a success</param>
+    /// <param name="onError">Invoked when result is a failure</param>
+    /// <returns>A task for the async operation</returns>
+    Task SwitchAsync(Func<TValue, Task> onSuccess, Func<IError, Task> onError);
+
+    /// <summary>
+    /// Evaluate the result in style of a discriminated union. A result must be returned
+    /// </summary>
+    /// <param name="onSuccess">Invoked when result is a success</param>
+    /// <param name="onError">Invoked when result is a failure</param>
+    /// <typeparam name="TReturn">Type to be returned</typeparam>
+    /// <returns>The result of the operation</returns>
+    TReturn Match<TReturn>(Func<TValue, TReturn> onSuccess,
+	    Func<IError, TReturn> onError);
+
+    /// <summary>
+    /// Evaluate the result in style of a discriminated union. A result must be returned
+    /// </summary>
+    /// <param name="onSuccess">Invoked when result is a success</param>
+    /// <param name="onError">Invoked when result is a failure</param>
+    /// <typeparam name="TReturn">Type to be returned</typeparam>
+    /// <returns>The result of the operation</returns>
+    Task<TReturn> MatchAsync<TReturn>(Func<TValue, Task<TReturn>> onSuccess, Func<IError, Task<TReturn>> onError);
 }

--- a/src/LightResults/Result.cs
+++ b/src/LightResults/Result.cs
@@ -403,6 +403,80 @@ public readonly struct Result : IEquatable<Result>,
         return false;
     }
 
+    /// <inheritdoc />
+    public void Switch(Action onSuccess, Action<IError> onError)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onError);
+#else
+        if (onSuccess is null) throw new ArgumentNullException(nameof(onSuccess));
+        if (onError is null) throw new ArgumentNullException(nameof(onError));
+#endif
+        
+        if (IsFailure(out var internalError))
+            onError(internalError);
+        else
+            onSuccess();
+    }
+
+    /// <inheritdoc />
+    public Task SwitchAsync(Func<Task> onSuccess, Func<IError, Task> onError)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onError);
+#else
+        if (onSuccess is null) throw new ArgumentNullException(nameof(onSuccess));
+        if (onError is null) throw new ArgumentNullException(nameof(onError));
+#endif
+        
+        if (IsFailure(out var internalError))
+        {
+            return onError(internalError);
+        }
+
+        return onSuccess();
+    }
+
+    /// <inheritdoc />
+    public TReturn Match<TReturn>(Func<TReturn> onSuccess, Func<IError, TReturn> onError)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onError);
+#else
+        if (onSuccess is null) throw new ArgumentNullException(nameof(onSuccess));
+        if (onError is null) throw new ArgumentNullException(nameof(onError));
+#endif
+        
+        if (IsFailure(out var internalError))
+        {
+            return onError(internalError);
+        }
+
+        return onSuccess();
+    }
+
+    /// <inheritdoc />
+    public Task<TReturn> MatchAsync<TReturn>(Func<Task<TReturn>> onSuccess, Func<IError, Task<TReturn>> onError)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onError);
+#else
+        if (onSuccess is null) throw new ArgumentNullException(nameof(onSuccess));
+        if (onError is null) throw new ArgumentNullException(nameof(onError));
+#endif
+        
+        if (IsFailure(out var internalError))
+        {
+            return onError(internalError);
+        }
+
+        return onSuccess();
+    }
+
     /// <summary>Implicitly converts an <see cref="Error"/> to a failure <see cref="Result{TValue}"/>.</summary>
     /// <param name="error">The error to convert into a failure result.</param>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error.</returns>

--- a/src/LightResults/Result`1.cs
+++ b/src/LightResults/Result`1.cs
@@ -126,6 +126,84 @@ public readonly struct Result<TValue> : IEquatable<Result<TValue>>,
         return !_isSuccess;
     }
 
+    /// <inheritdoc />
+    public void Switch(Action<TValue> onSuccess, Action<IError> onError)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onError);
+#else
+        if (onSuccess is null) throw new ArgumentNullException(nameof(onSuccess));
+        if (onError is null) throw new ArgumentNullException(nameof(onError));
+#endif
+        
+        if (IsFailure(out var internalError, out var value))
+        {
+            onError(internalError);
+        }
+        else
+        {
+            onSuccess(value);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task SwitchAsync(Func<TValue, Task> onSuccess, Func<IError, Task> onError)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onError);
+#else
+        if (onSuccess is null) throw new ArgumentNullException(nameof(onSuccess));
+        if (onError is null) throw new ArgumentNullException(nameof(onError));
+#endif
+        
+        if (IsFailure(out var internalError, out var value))
+        {
+            return onError(internalError);
+        }
+
+        return onSuccess(value);
+    }
+
+    /// <inheritdoc />
+    public TReturn Match<TReturn>(Func<TValue, TReturn> onSuccess, Func<IError, TReturn> onError)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onError);
+#else
+        if (onSuccess is null) throw new ArgumentNullException(nameof(onSuccess));
+        if (onError is null) throw new ArgumentNullException(nameof(onError));
+#endif
+        
+        if (IsFailure(out var internalError, out var value))
+        {
+            return onError(internalError);
+        }
+
+        return onSuccess(value);
+    }
+
+    /// <inheritdoc />
+    public Task<TReturn> MatchAsync<TReturn>(Func<TValue, Task<TReturn>> onSuccess, Func<IError, Task<TReturn>> onError)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onError);
+#else
+        if (onSuccess is null) throw new ArgumentNullException(nameof(onSuccess));
+        if (onError is null) throw new ArgumentNullException(nameof(onError));
+#endif
+        
+        if (IsFailure(out var internalError, out var value))
+        {
+            return onError(internalError);
+        }
+
+        return onSuccess(value);
+    }
+
 #if NET7_0_OR_GREATER
     /// <summary>Creates a success result with the specified value.</summary>
     /// <param name="value">The value to include in the result.</param>
@@ -267,6 +345,80 @@ public readonly struct Result<TValue> : IEquatable<Result<TValue>>,
 
         error = default;
         return false;
+    }
+
+    /// <inheritdoc />
+    public void Switch(Action onSuccess, Action<IError> onError)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onError);
+#else
+        if (onSuccess is null) throw new ArgumentNullException(nameof(onSuccess));
+        if (onError is null) throw new ArgumentNullException(nameof(onError));
+#endif
+        
+        if (IsFailure(out var internalError))
+            onError(internalError);
+        else
+            onSuccess();
+    }
+
+    /// <inheritdoc />
+    public Task SwitchAsync(Func<Task> onSuccess, Func<IError, Task> onError)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onError);
+#else
+        if (onSuccess is null) throw new ArgumentNullException(nameof(onSuccess));
+        if (onError is null) throw new ArgumentNullException(nameof(onError));
+#endif
+        
+        if (IsFailure(out var internalError))
+        {
+            return onError(internalError);
+        }
+
+        return onSuccess();
+    }
+
+    /// <inheritdoc />
+    public TReturn Match<TReturn>(Func<TReturn> onSuccess, Func<IError, TReturn> onError)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onError);
+#else
+        if (onSuccess is null) throw new ArgumentNullException(nameof(onSuccess));
+        if (onError is null) throw new ArgumentNullException(nameof(onError));
+#endif
+        
+        if (IsFailure(out var internalError))
+        {
+            return onError(internalError);
+        }
+
+        return onSuccess();
+    }
+
+    /// <inheritdoc />
+    public Task<TReturn> MatchAsync<TReturn>(Func<Task<TReturn>> onSuccess, Func<IError, Task<TReturn>> onError)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(onSuccess);
+        ArgumentNullException.ThrowIfNull(onError);
+#else
+        if (onSuccess is null) throw new ArgumentNullException(nameof(onSuccess));
+        if (onError is null) throw new ArgumentNullException(nameof(onError));
+#endif
+        
+        if (IsFailure(out var internalError))
+        {
+            return onError(internalError);
+        }
+
+        return onSuccess();
     }
 
     /// <summary>Implicitly converts a value to a success <see cref="Result{TValue}"/>.</summary>

--- a/tests/LightResults.Tests/ResultTValueTests.cs
+++ b/tests/LightResults.Tests/ResultTValueTests.cs
@@ -1969,4 +1969,158 @@ public sealed class ResultTValueTests
             .Be($"Result {{ {expected} }}");
     }
 #endif
+    
+    [Fact]
+    public void Switch_WhenSuccess_ShouldInvokeOnSuccess()
+    {
+        // Arrange
+        var result = Result.Success(47);
+        var onSuccessCalled = false;
+        
+        // Act
+        result.Switch(value =>
+        {
+            value.Should().Be(47);
+            onSuccessCalled = true;
+        }, error =>
+        {
+            Assert.Fail("onError should not be invoked");
+        });
+        
+        // Assert
+        onSuccessCalled.Should().BeTrue();
+    }
+    
+    [Fact]
+    public void Switch_WhenFailure_ShouldInvokeOnError()
+    {
+        // Arrange
+        var result = Result.Failure(new Error("Failure"));
+        var onErrorCalled = false;
+        
+        // Act
+        result.Switch(() =>
+        {
+            Assert.Fail("onSuccess should not be invoked");
+        }, error =>
+        {
+            error.Message.Should().Be("Failure");
+            onErrorCalled = true;
+        });
+        
+        // Assert
+        onErrorCalled.Should().BeTrue();
+    }
+    
+    [Fact]
+    public async Task SwitchAsync_WhenSuccess_ShouldInvokeOnSuccess()
+    {
+        // Arrange
+        var result = Result.Success(47);
+        var onSuccessCalled = false;
+        
+        // Act
+        await result.SwitchAsync(value =>
+        {
+            value.Should().Be(47);
+            onSuccessCalled = true;
+            return Task.CompletedTask;
+        }, error =>
+        {
+            Assert.Fail("onError should not be invoked");
+            return Task.CompletedTask;
+        });
+        
+        // Assert
+        onSuccessCalled.Should().BeTrue();
+    }
+    
+    [Fact]
+    public async Task SwitchAsync_WhenFailure_ShouldInvokeOnError()
+    {
+        // Arrange
+        var result = Result.Failure(new Error("Failure"));
+        var onErrorCalled = false;
+        
+        // Act
+        await result.SwitchAsync(() =>
+        {
+            Assert.Fail("onSuccess should not be invoked");
+            return Task.CompletedTask;
+        }, error =>
+        {
+            error.Message.Should().Be("Failure");
+            onErrorCalled = true;
+            return Task.CompletedTask;
+        });
+        
+        // Assert
+        onErrorCalled.Should().BeTrue();
+    }
+    
+    [Fact]
+    public void Match_WhenSuccess_ShouldInvokeOnSuccess()
+    {
+        // Arrange
+        var result = Result.Success(47);
+        
+        // Assert
+        result.Match(value =>
+        {
+            value.Should().Be(47);
+            return true;
+        }, _ =>
+        {
+            return false;
+        }).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void Match_WhenFailure_ShouldInvokeOnError()
+    {
+        // Arrange
+        var result = Result.Failure("Failure");
+        
+        // Assert
+        result.Match(() => false, error =>
+        {
+            error.Message.Should().Be("Failure");
+            return true;
+        }).Should().BeTrue();
+    }
+    
+    [Fact]
+    public async Task MatchAsync_WhenSuccess_ShouldInvokeOnSuccess()
+    {
+        // Arrange
+        var result = Result.Success(47);
+        
+        // Assert
+        var match = await result.MatchAsync<bool>(value =>
+        {
+            value.Should().Be(47);
+            return Task.FromResult(true);
+        }, _ =>
+        {
+            return Task.FromResult(false);
+        });
+
+        match.Should().BeTrue();
+    }
+    
+    [Fact]
+    public async Task MatchAsync_WhenFailure_ShouldInvokeOnError()
+    {
+        // Arrange
+        var result = Result.Failure("Failure");
+        
+        // Assert
+        var match = await result.MatchAsync(() => Task.FromResult(false), error =>
+        {
+            error.Message.Should().Be("Failure");
+            return Task.FromResult(true);
+        });
+
+        match.Should().BeTrue();
+    }
 }

--- a/tests/LightResults.Tests/ResultTests.cs
+++ b/tests/LightResults.Tests/ResultTests.cs
@@ -1549,4 +1549,140 @@ public sealed class ResultTests
         }
     }
 #endif
+
+    [Fact]
+    public void Switch_WhenSuccess_ShouldInvokeOnSuccess()
+    {
+        // Arrange
+        var result = Result.Success();
+        var onSuccessCalled = false;
+        var onFailureCalled = false;
+        
+        // Act
+        result.Switch(() =>
+        {
+            onSuccessCalled = true;
+        }, _ =>
+        {
+            onFailureCalled = true;
+        });
+        
+        // Assert
+        onSuccessCalled.Should().BeTrue();
+        onFailureCalled.Should().BeFalse();
+    }
+    
+    [Fact]
+    public void Switch_WhenFailure_ShouldInvokeOnError()
+    {
+        // Arrange
+        var result = Result.Failure();
+        var onSuccessCalled = false;
+        var onFailureCalled = false;
+        
+        // Act
+        result.Switch(() =>
+        {
+            onSuccessCalled = true;
+        }, _ =>
+        {
+            onFailureCalled = true;
+        });
+        
+        // Assert
+        onSuccessCalled.Should().BeFalse();
+        onFailureCalled.Should().BeTrue();
+    }
+    
+    [Fact]
+    public async Task SwitchAsync_WhenSuccess_ShouldInvokeOnSuccess()
+    {
+        // Arrange
+        var result = Result.Success();
+        var onSuccessCalled = false;
+        var onFailureCalled = false;
+        
+        // Act
+        await result.SwitchAsync(() =>
+        {
+            onSuccessCalled = true;
+            return Task.CompletedTask;
+        }, _ =>
+        {
+            onFailureCalled = true;
+            return Task.CompletedTask;
+        });
+        
+        // Assert
+        onSuccessCalled.Should().BeTrue();
+        onFailureCalled.Should().BeFalse();
+    }
+    
+    [Fact]
+    public async Task SwitchAsync_WhenFailure_ShouldInvokeOnError()
+    {
+        // Arrange
+        var result = Result.Failure();
+        var onSuccessCalled = false;
+        var onFailureCalled = false;
+        
+        // Act
+        await result.SwitchAsync(() =>
+        {
+            onSuccessCalled = true;
+            return Task.CompletedTask;
+        }, _ =>
+        {
+            onFailureCalled = true;
+            return Task.CompletedTask;
+        });
+        
+        // Assert
+        onSuccessCalled.Should().BeFalse();
+        onFailureCalled.Should().BeTrue();
+    }
+    
+    [Fact]
+    public void Match_WhenSuccess_ShouldInvokeOnSuccess()
+    {
+        // Arrange
+        var result = Result.Success();
+        
+        // Assert
+        result.Match(() => true, _ => false).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void Match_WhenFailure_ShouldInvokeOnError()
+    {
+        // Arrange
+        var result = Result.Failure();
+        
+        // Assert
+        result.Match(() => false, _ => true).Should().BeTrue();
+    }
+    
+    [Fact]
+    public async Task MatchAsync_WhenSuccess_ShouldInvokeOnSuccess()
+    {
+        // Arrange
+        var result = Result.Success();
+        
+        // Assert
+        var match = await result.MatchAsync(() => Task.FromResult(true), _ => Task.FromResult(false));
+
+        match.Should().BeTrue();
+    }
+    
+    [Fact]
+    public async Task MatchAsync_WhenFailure_ShouldInvokeOnError()
+    {
+        // Arrange
+        var result = Result.Failure();
+        
+        // Assert
+        var match = await result.MatchAsync(() => Task.FromResult(false), _ => Task.FromResult(true));
+
+        match.Should().BeTrue();
+    }
 }


### PR DESCRIPTION
Hey, i do like the simplicity of your implementation. However i do like the handling that acts like a discriminated union some other implementation offer. So i implemented this api. No existing api's are harmed, just some additions.

For me personally the first sample(following) does read a little better than the second one. Also the compiler will ensure that both cases will be handled by the caller.

```c#
public async Task<Result<ItemEntity>> UpdateItemAsync(UpdateItemRequest request, CancellationToken cancellationToken = default)
{
	var validationResult = UpdateItemRequestValidator.Instance.Validate(request);
	if (!validationResult.IsValid)
	{
		return AppError.Invalid<ItemEntity>(validationResult);
	}
	
	// Does the item exist?
	var itemResult = await ItemRepository.GetByIdAsync(request.Id, cancellationToken: cancellationToken);
	
	return await itemResult.MatchAsync(async entity =>
	{
		entity.UpdateItemNumber(request.ItemNumber);
		entity.UpdateName(request.Name);
		entity.UpdateDescription(request.Description);
	
		var result = await ItemRepository.UpdateAsync(entity, cancellationToken: cancellationToken);
		_unitOfWork.SaveChanges();
		return result;
	}, _ => Task.FromResult(itemResult));
}
```

```c#
public async Task<Result<ItemEntity>> UpdateItemAsync(UpdateItemRequest request, CancellationToken cancellationToken = default)
{
	var validationResult = UpdateItemRequestValidator.Instance.Validate(request);
	if (!validationResult.IsValid)
	{
		return AppError.Invalid<ItemEntity>(validationResult);
	}
	
	// Does the item exist?
	var itemResult = await ItemRepository.GetByIdAsync(request.Id, cancellationToken: cancellationToken);
	if (itemResult.IsFailure(out _, out var entity))
	{
		return itemResult;
	}
	
	entity.UpdateItemNumber(request.ItemNumber);
	entity.UpdateName(request.Name);
	entity.UpdateDescription(request.Description);

	var result = await ItemRepository.UpdateAsync(entity, cancellationToken: cancellationToken);
	_unitOfWork.SaveChanges();
	return result;
}

```