### PR TITLE
Fix typos in docs, tests, and benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ if (result.IsFailure(out var error))
     if (error.Message.Length > 0)
         Console.WriteLine(error.Message);
     else
-        Console.WriteLine("An unknown error occured!");
+        Console.WriteLine("An unknown error occurred!");
 }
 ```
 
@@ -166,7 +166,7 @@ This can be especially useful when combined with metadata that is related to a s
 public sealed class HttpError : Error
 {
     public HttpError(HttpStatusCode statusCode)
-        : base("An HTTP error occured.", ("StatusCode", statusCode))
+        : base("An HTTP error occurred.", ("StatusCode", statusCode))
     {
     }
 }

--- a/docfx/docs/getting-started.md
+++ b/docfx/docs/getting-started.md
@@ -47,7 +47,7 @@ if (result.IsFailure(out var error))
     if (error.Message.Length > 0)
         Console.WriteLine(error.Message);
     else
-        Console.WriteLine("An unknown error occured!");
+        Console.WriteLine("An unknown error occurred!");
 }
 ```
 
@@ -123,7 +123,7 @@ This can be especially useful when combined with metadata that is related to a s
 public sealed class HttpError : Error
 {
     public HttpError(HttpStatusCode statusCode)
-        : base("An HTTP error occured.", ("StatusCode", statusCode))
+        : base("An HTTP error occurred.", ("StatusCode", statusCode))
     {
     }
 }

--- a/tests/LightResults.Tests/CustomErrorTests.cs
+++ b/tests/LightResults.Tests/CustomErrorTests.cs
@@ -51,7 +51,7 @@ public sealed class CustomErrorTests
 
     [Theory]
     [InlineData("")]
-    [InlineData("An unknown error occured!")]
+    [InlineData("An unknown error occurred!")]
     public void ToString_ShouldReturnStringRepresentation(string errorMessage)
     {
         // Arrange

--- a/tests/LightResults.Tests/ErrorTests.cs
+++ b/tests/LightResults.Tests/ErrorTests.cs
@@ -146,7 +146,7 @@ public sealed class ErrorTests
 
     [Theory]
     [InlineData("")]
-    [InlineData("An unknown error occured!")]
+    [InlineData("An unknown error occurred!")]
     public void ToString_ShouldReturnStringRepresentation(string errorMessage)
     {
         // Arrange
@@ -154,5 +154,4 @@ public sealed class ErrorTests
 
         // Assert
         error.ToString().ShouldBe(errorMessage.Length > 0 ? $"Error {{ Message = \"{errorMessage}\" }}" : "Error");
-    }
-}
+    }}

--- a/tests/LightResults.Tests/ResultTValueTests.cs
+++ b/tests/LightResults.Tests/ResultTValueTests.cs
@@ -855,7 +855,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = True", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForBoolean(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -868,7 +868,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = 1", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForSByte(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -881,7 +881,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = 1", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForByte(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -894,7 +894,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = 1", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForInt16(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -907,7 +907,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = 1", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForUInt16(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -920,7 +920,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = 1", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForInt32(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -933,7 +933,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = 1", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForUInt32(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -946,7 +946,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = 1", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForInt64(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -959,7 +959,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = 1", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForUInt64(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -972,7 +972,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = 1.1", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForDecimal(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -985,7 +985,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = 1.1", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForFloat(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -998,7 +998,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = 1.1", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForDouble(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1011,7 +1011,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = \"2024-04-05T12:30:00Z\"", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForDateTime(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1026,7 +1026,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = \"2024-04-05T12:30:00+00:00\"", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForDateTimeOffset(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1041,7 +1041,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = 'c'", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForChar(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1054,7 +1054,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = \"StringValue\"", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForString(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1067,7 +1067,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForObject(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1080,7 +1080,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = 1", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForNullableValueTypes(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1334,7 +1334,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = \"2024-04-05\"", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForDateOnly(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1347,7 +1347,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = \"12:30:00\"", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForTimeOnly(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1362,7 +1362,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = 1", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForInt128(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1375,7 +1375,7 @@ public sealed class ResultTValueTests
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = 1", "")]
     [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occured!\"", "An unknown error occured!")]
+    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForUInt128(bool success, string expected, string errorMessage)
     {
         // Arrange

--- a/tests/LightResults.Tests/ResultTests.cs
+++ b/tests/LightResults.Tests/ResultTests.cs
@@ -876,7 +876,7 @@ public sealed class ResultTests
 
     [Theory]
     [InlineData("")]
-    [InlineData("An unknown error occured!")]
+    [InlineData("An unknown error occurred!")]
     public void ToString_WhenFailure_ShouldReturnStringRepresentation(string errorMessage)
     {
         // Arrange

--- a/tools/LightResults.ComparisonBenchmarks/Benchmarks.cs
+++ b/tools/LightResults.ComparisonBenchmarks/Benchmarks.cs
@@ -17,5 +17,5 @@ public partial class Benchmarks
     public int Iterations { get; set; }
 
     private const int ResultValue = 0;
-    private const string ErrorMessage = "An unknown error occured.";
+    private const string ErrorMessage = "An unknown error occurred.";
 }

--- a/tools/LightResults.CurrentBenchmarks/Benchmarks.cs
+++ b/tools/LightResults.CurrentBenchmarks/Benchmarks.cs
@@ -16,7 +16,7 @@ public class Benchmarks
     public int Iterations { get; set; }
 
     private const int ResultValue = 0;
-    private const string ErrorMessage = "An unknown error occured.";
+    private const string ErrorMessage = "An unknown error occurred.";
     private static readonly Error EmptyError = new();
     private static readonly Error ErrorWithErrorMessage = new(ErrorMessage);
     private static readonly Result ResultSuccess = Result.Success();

--- a/tools/LightResults.DevelopBenchmarks/Benchmarks.cs
+++ b/tools/LightResults.DevelopBenchmarks/Benchmarks.cs
@@ -15,7 +15,7 @@ public class Benchmarks
     public int Iterations { get; set; }
 
     private const int ResultValue = 0;
-    private const string ErrorMessage = "An unknown error occured.";
+    private const string ErrorMessage = "An unknown error occurred.";
     private static readonly Error EmptyError = new();
     private static readonly Error ErrorWithErrorMessage = new(ErrorMessage);
     private static readonly Result ResultOk = Result.Success();


### PR DESCRIPTION
## Summary
- fix spelling of `occurred` in documentation and tests
- update benchmarks with corrected error message spelling

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj` *(fails: Could not find 'mono' host)*
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_686d48eda5508328a851d5e852f63657