### PR TITLE
Allow nullable exceptions for Failure

### DIFF
--- a/src/LightResults/Common/IActionableResult.cs
+++ b/src/LightResults/Common/IActionableResult.cs
@@ -22,19 +22,19 @@ public interface IActionableResult<out TResult> : IResult
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <returns>A new instance of <typeparamref name="TResult"/> representing a failure result with the specified error message and metadata.</returns>
-    static abstract TResult Failure(string errorMessage, (string Key, object Value) metadata);
+    static abstract TResult Failure(string errorMessage, (string Key, object? Value) metadata);
 
     /// <summary>Creates a failure result with the given error message and metadata.</summary>
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <returns>A new instance of <typeparamref name="TResult"/> representing a failure result with the specified error message and metadata.</returns>
-    static abstract TResult Failure(string errorMessage, KeyValuePair<string, object> metadata);
+    static abstract TResult Failure(string errorMessage, KeyValuePair<string, object?> metadata);
 
     /// <summary>Creates a failure result with the given error message and metadata.</summary>
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <returns>A new instance of <typeparamref name="TResult"/> representing a failure result with the specified error message and metadata.</returns>
-    static abstract TResult Failure(string errorMessage, IReadOnlyDictionary<string, object> metadata);
+    static abstract TResult Failure(string errorMessage, IReadOnlyDictionary<string, object?> metadata);
 
     /// <summary>Creates a failure result with the given error.</summary>
     /// <param name="error">The error associated with the failure.</param>
@@ -74,19 +74,19 @@ public interface IActionableResult<TValue, out TResult> : IResult<TValue>
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <returns>A new instance of <typeparamref name="TResult"/> representing a failure result with the specified error message and metadata.</returns>
-    static abstract TResult Failure(string errorMessage, (string Key, object Value) metadata);
+    static abstract TResult Failure(string errorMessage, (string Key, object? Value) metadata);
 
     /// <summary>Creates a failure result with the given error message and metadata.</summary>
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <returns>A new instance of <typeparamref name="TResult"/> representing a failure result with the specified error message and metadata.</returns>
-    static abstract TResult Failure(string errorMessage, KeyValuePair<string, object> metadata);
+    static abstract TResult Failure(string errorMessage, KeyValuePair<string, object?> metadata);
 
     /// <summary>Creates a failure result with the given error message and metadata.</summary>
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <returns>A new instance of <typeparamref name="TResult"/> representing a failure result with the specified error message and metadata.</returns>
-    static abstract TResult Failure(string errorMessage, IReadOnlyDictionary<string, object> metadata);
+    static abstract TResult Failure(string errorMessage, IReadOnlyDictionary<string, object?> metadata);
 
     /// <summary>Creates a failure result with the given error.</summary>
     /// <param name="error">The error associated with the failure.</param>

--- a/src/LightResults/Error.cs
+++ b/src/LightResults/Error.cs
@@ -9,12 +9,12 @@ public class Error : IError
     public string Message { get; init; }
 
     /// <inheritdoc/>
-    public IReadOnlyDictionary<string, object> Metadata { get; init; }
+    public IReadOnlyDictionary<string, object?> Metadata { get; init; }
 
-    internal static IError Empty { get; } = new Error("", new Dictionary<string, object>());
+    internal static IError Empty { get; } = new Error("", new Dictionary<string, object?>());
     internal static IReadOnlyList<IError> EmptyErrorList { get; } = [];
-    internal static IReadOnlyList<IError> DefaultErrorList { get; } = [new Error("", new Dictionary<string, object>())];
-    private static readonly IReadOnlyDictionary<string, object> EmptyMetaData = new Dictionary<string, object>();
+    internal static IReadOnlyList<IError> DefaultErrorList { get; } = [new Error("", new Dictionary<string, object?>())];
+    private static readonly IReadOnlyDictionary<string, object?> EmptyMetaData = new Dictionary<string, object?>();
 
     /// <summary>Initializes a new instance of the <see cref="Error"/> class.</summary>
     public Error()
@@ -33,10 +33,10 @@ public class Error : IError
     /// <summary>Initializes a new instance of the <see cref="Error"/> class with the specified error message and metadata.</summary>
     /// <param name="message">The error message.</param>
     /// <param name="metadata">The metadata associated with the error.</param>
-    public Error(string message, (string Key, object Value) metadata)
+    public Error(string message, (string Key, object? Value) metadata)
     {
         Message = message;
-        Metadata = new Dictionary<string, object>(1)
+        Metadata = new Dictionary<string, object?>(1)
         {
             { metadata.Key, metadata.Value },
         };
@@ -45,10 +45,10 @@ public class Error : IError
     /// <summary>Initializes a new instance of the <see cref="Error"/> class with the specified error message and metadata.</summary>
     /// <param name="message">The error message.</param>
     /// <param name="metadata">The metadata associated with the error.</param>
-    public Error(string message, KeyValuePair<string, object> metadata)
+    public Error(string message, KeyValuePair<string, object?> metadata)
     {
         Message = message;
-        Metadata = new Dictionary<string, object>(1)
+        Metadata = new Dictionary<string, object?>(1)
         {
             { metadata.Key, metadata.Value },
         };
@@ -58,17 +58,17 @@ public class Error : IError
     /// <summary>Initializes a new instance of the <see cref="Error"/> class with the specified error message and metadata.</summary>
     /// <param name="message">The error message.</param>
     /// <param name="metadata">The metadata associated with the error.</param>
-    public Error(string message, IEnumerable<KeyValuePair<string, object>> metadata)
+    public Error(string message, IEnumerable<KeyValuePair<string, object?>> metadata)
     {
         Message = message;
-        Metadata = new Dictionary<string, object>(metadata);
+        Metadata = new Dictionary<string, object?>(metadata);
     }
 #endif
 
     /// <summary>Initializes a new instance of the <see cref="Error"/> class with the specified error message and metadata.</summary>
     /// <param name="message">The error message.</param>
     /// <param name="metadata">The metadata associated with the error.</param>
-    public Error(string message, IReadOnlyDictionary<string, object> metadata)
+    public Error(string message, IReadOnlyDictionary<string, object?> metadata)
     {
         Message = message;
         Metadata = metadata;

--- a/src/LightResults/IError.cs
+++ b/src/LightResults/IError.cs
@@ -11,7 +11,7 @@ public interface IError
     /// <returns>An <see cref="IReadOnlyDictionary{TKey, TValue}"/> containing the metadata.</returns>
     /// <remarks>
     /// The metadata is represented as a read-only dictionary of key-value pairs, where the keys are <see cref="string"/> and the values are
-    /// <see cref="object"/>.
+    /// <see cref="object"/> which may be <see langword="null"/>.
     /// </remarks>
-    IReadOnlyDictionary<string, object> Metadata { get; }
+    IReadOnlyDictionary<string, object?> Metadata { get; }
 }

--- a/src/LightResults/Result.cs
+++ b/src/LightResults/Result.cs
@@ -93,9 +93,9 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified error message and metadata.</returns>
-    public static Result Failure(string errorMessage, (string Key, object Value) metadata)
+    public static Result Failure(string errorMessage, (string Key, object? Value) metadata)
     {
-        var dictionary = new Dictionary<string, object>(1)
+        var dictionary = new Dictionary<string, object?>(1)
         {
             { metadata.Key, metadata.Value },
         };
@@ -107,9 +107,9 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified error message and metadata.</returns>
-    public static Result Failure(string errorMessage, KeyValuePair<string, object> metadata)
+    public static Result Failure(string errorMessage, KeyValuePair<string, object?> metadata)
     {
-        var dictionary = new Dictionary<string, object>(1)
+        var dictionary = new Dictionary<string, object?>(1)
         {
             { metadata.Key, metadata.Value },
         };
@@ -121,50 +121,38 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified error message and metadata.</returns>
-    public static Result Failure(string errorMessage, IReadOnlyDictionary<string, object> metadata)
+    public static Result Failure(string errorMessage, IReadOnlyDictionary<string, object?> metadata)
     {
         var error = new Error(errorMessage, metadata);
         return new Result(error);
     }
 
     /// <summary>Creates a failure result with the given exception.</summary>
-    /// <param name="ex">The <see cref="Exception"/> associated with the failure.</param>
+    /// <param name="ex">The <see cref="Exception"/> associated with the failure, if any.</param>
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified exception.</returns>
     /// <remarks>
     /// The exception is added to the error <see cref="Error.Metadata"/> under the key of "Exception" and the error <see cref="Error.Message"/> is set to that
     /// of the exception.
     /// </remarks>
-    public static Result Failure(Exception ex)
+    public static Result Failure(Exception? ex)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(ex);
-#else
-        if (ex is null)
-            throw new ArgumentNullException(nameof(ex));
-#endif
-        var metadata = new Dictionary<string, object>(1)
+        var metadata = new Dictionary<string, object?>(1)
         {
             { "Exception", ex },
         };
-        var error = new Error(ex.Message, metadata);
+        var message = ex?.Message ?? string.Empty;
+        var error = new Error(message, metadata);
         return new Result(error);
     }
 
     /// <summary>Creates a failure result with the given error message and exception.</summary>
     /// <param name="errorMessage">The error message associated with the failure.</param>
-    /// <param name="ex">The <see cref="Exception"/> associated with the failure.</param>
+    /// <param name="ex">The <see cref="Exception"/> associated with the failure, if any.</param>
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified error message and exception.</returns>
     /// <remarks>The exception is added to the error <see cref="Error.Metadata"/> under the key of "Exception".</remarks>
-    public static Result Failure(string errorMessage, Exception ex)
+    public static Result Failure(string errorMessage, Exception? ex)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(ex);
-#else
-        if (ex is null)
-            throw new ArgumentNullException(nameof(ex));
-#endif
-
-        var metadata = new Dictionary<string, object>(1)
+        var metadata = new Dictionary<string, object?>(1)
         {
             { "Exception", ex },
         };
@@ -219,9 +207,9 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <typeparam name="TValue">The type of the value of the result.</typeparam>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message and metadata.</returns>
-    public static Result<TValue> Failure<TValue>(string errorMessage, (string Key, object Value) metadata)
+    public static Result<TValue> Failure<TValue>(string errorMessage, (string Key, object? Value) metadata)
     {
-        var dictionary = new Dictionary<string, object>(1)
+        var dictionary = new Dictionary<string, object?>(1)
         {
             { metadata.Key, metadata.Value },
         };
@@ -234,9 +222,9 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <typeparam name="TValue">The type of the value of the result.</typeparam>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message and metadata.</returns>
-    public static Result<TValue> Failure<TValue>(string errorMessage, KeyValuePair<string, object> metadata)
+    public static Result<TValue> Failure<TValue>(string errorMessage, KeyValuePair<string, object?> metadata)
     {
-        var dictionary = new Dictionary<string, object>(1)
+        var dictionary = new Dictionary<string, object?>(1)
         {
             { metadata.Key, metadata.Value },
         };
@@ -249,50 +237,38 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <typeparam name="TValue">The type of the value of the result.</typeparam>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message and metadata.</returns>
-    public static Result<TValue> Failure<TValue>(string errorMessage, IReadOnlyDictionary<string, object> metadata)
+    public static Result<TValue> Failure<TValue>(string errorMessage, IReadOnlyDictionary<string, object?> metadata)
     {
         var error = new Error(errorMessage, metadata);
         return new Result<TValue>(error);
     }
 
     /// <summary>Creates a failure result with the given exception.</summary>
-    /// <param name="ex">The <see cref="Exception"/> associated with the failure.</param>
+    /// <param name="ex">The <see cref="Exception"/> associated with the failure, if any.</param>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified exception.</returns>
     /// <remarks>
     /// The exception is added to the error <see cref="Error.Metadata"/> under the key of "Exception" and the error <see cref="Error.Message"/> is set to that
     /// of the exception.
     /// </remarks>
-    public static Result<TValue> Failure<TValue>(Exception ex)
+    public static Result<TValue> Failure<TValue>(Exception? ex)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(ex);
-#else
-        if (ex is null)
-            throw new ArgumentNullException(nameof(ex));
-#endif
-        var metadata = new Dictionary<string, object>(1)
+        var metadata = new Dictionary<string, object?>(1)
         {
             { "Exception", ex },
         };
-        var error = new Error(ex.Message, metadata);
+        var message = ex?.Message ?? string.Empty;
+        var error = new Error(message, metadata);
         return new Result<TValue>(error);
     }
 
     /// <summary>Creates a failure result with the given error message and exception.</summary>
     /// <param name="errorMessage">The error message associated with the failure.</param>
-    /// <param name="ex">The <see cref="Exception"/> associated with the failure.</param>
+    /// <param name="ex">The <see cref="Exception"/> associated with the failure, if any.</param>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message and exception.</returns>
     /// <remarks>The exception is added to the error <see cref="Error.Metadata"/> under the key of "Exception".</remarks>
-    public static Result<TValue> Failure<TValue>(string errorMessage, Exception ex)
+    public static Result<TValue> Failure<TValue>(string errorMessage, Exception? ex)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(ex);
-#else
-        if (ex is null)
-            throw new ArgumentNullException(nameof(ex));
-#endif
-
-        var metadata = new Dictionary<string, object>(1)
+        var metadata = new Dictionary<string, object?>(1)
         {
             { "Exception", ex },
         };

--- a/src/LightResults/Result`1.cs
+++ b/src/LightResults/Result`1.cs
@@ -155,12 +155,12 @@ public readonly struct Result<TValue> : IEquatable<Result<TValue>>,
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message.</returns>
-    static Result<TValue> IActionableResult<TValue, Result<TValue>>.Failure(string errorMessage, (string Key, object Value) metadata)
+static Result<TValue> IActionableResult<TValue, Result<TValue>>.Failure(string errorMessage, (string Key, object? Value) metadata)
+{
+    var dictionary = new Dictionary<string, object?>(1)
     {
-        var dictionary = new Dictionary<string, object>(1)
-        {
-            { metadata.Key, metadata.Value },
-        };
+        { metadata.Key, metadata.Value },
+    };
         var error = new Error(errorMessage, dictionary);
         return new Result<TValue>(error);
     }
@@ -169,12 +169,12 @@ public readonly struct Result<TValue> : IEquatable<Result<TValue>>,
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message.</returns>
-    static Result<TValue> IActionableResult<TValue, Result<TValue>>.Failure(string errorMessage, KeyValuePair<string, object> metadata)
+static Result<TValue> IActionableResult<TValue, Result<TValue>>.Failure(string errorMessage, KeyValuePair<string, object?> metadata)
+{
+    var dictionary = new Dictionary<string, object?>(1)
     {
-        var dictionary = new Dictionary<string, object>(1)
-        {
-            { metadata.Key, metadata.Value },
-        };
+        { metadata.Key, metadata.Value },
+    };
         var error = new Error(errorMessage, dictionary);
         return new Result<TValue>(error);
     }
@@ -183,7 +183,7 @@ public readonly struct Result<TValue> : IEquatable<Result<TValue>>,
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message.</returns>
-    static Result<TValue> IActionableResult<TValue, Result<TValue>>.Failure(string errorMessage, IReadOnlyDictionary<string, object> metadata)
+static Result<TValue> IActionableResult<TValue, Result<TValue>>.Failure(string errorMessage, IReadOnlyDictionary<string, object?> metadata)
     {
         var error = new Error(errorMessage, metadata);
         return new Result<TValue>(error);

--- a/tests/LightResults.Tests/CustomErrorTests.cs
+++ b/tests/LightResults.Tests/CustomErrorTests.cs
@@ -34,7 +34,7 @@ public sealed class CustomErrorTests
     {
         // Arrange
         const string errorMessage = "Sample error message";
-        var metadata = new Dictionary<string, object>
+        var metadata = new Dictionary<string, object?>
         {
             { "Key1", "Value1" },
             { "Key2", 42 },
@@ -74,7 +74,7 @@ public sealed class CustomErrorTests
         {
         }
 
-        public CustomError(string errorMessage, IReadOnlyDictionary<string, object> metadata)
+        public CustomError(string errorMessage, IReadOnlyDictionary<string, object?> metadata)
             : base(errorMessage, metadata)
         {
         }

--- a/tests/LightResults.Tests/ErrorTests.cs
+++ b/tests/LightResults.Tests/ErrorTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using Shouldly;
 
 namespace LightResults.Tests;
@@ -53,7 +55,7 @@ public sealed class ErrorTests
     {
         // Arrange
         const string errorMessage = "Sample error message";
-        var metadata = new KeyValuePair<string, object>("Key1", "Value1");
+        var metadata = new KeyValuePair<string, object?>("Key1", "Value1");
 
         // Act
         var error = new Error(errorMessage, metadata);
@@ -73,7 +75,7 @@ public sealed class ErrorTests
     {
         // Arrange
         const string errorMessage = "Sample error message";
-        var metadata = new Dictionary<string, object>
+        var metadata = new Dictionary<string, object?>
         {
             { "Key1", "Value1" },
             { "Key2", 42 },
@@ -94,7 +96,7 @@ public sealed class ErrorTests
     {
         // Arrange
         const string errorMessage = "Sample error message";
-        var metadata = new Dictionary<string, object>
+        var metadata = new Dictionary<string, object?>
         {
             { "Key1", "Value1" },
             { "Key2", 42 },
@@ -128,7 +130,7 @@ public sealed class ErrorTests
     public void MetadataPropertyInit_ShouldCreateErrorWithMetadata()
     {
         // Arrange
-        var metadata = new Dictionary<string, object>
+        var metadata = new Dictionary<string, object?>
         {
             { "Key1", "Value1" },
             { "Key2", 42 },

--- a/tests/LightResults.Tests/ResultTValueTests.cs
+++ b/tests/LightResults.Tests/ResultTValueTests.cs
@@ -368,7 +368,7 @@ public sealed class ResultTValueTests
         var error = result.Errors.Single();
         error.Message.ShouldBe(errorMessage);
         error.Metadata.ShouldHaveSingleItem();
-        error.Metadata.Single().ShouldBeEquivalentTo(new KeyValuePair<string, object>("Key", 0));
+        error.Metadata.Single().ShouldBeEquivalentTo(new KeyValuePair<string, object?>("Key", 0));
     }
 
     [Fact]
@@ -376,7 +376,7 @@ public sealed class ResultTValueTests
     {
         // Arrange
         const string errorMessage = "Sample error message";
-        IReadOnlyDictionary<string, object> metadata = new Dictionary<string, object>
+        IReadOnlyDictionary<string, object?> metadata = new Dictionary<string, object?>
         {
             { "Key", 0 },
         };
@@ -393,7 +393,7 @@ public sealed class ResultTValueTests
         var error = result.Errors.Single();
         error.Message.ShouldBe(errorMessage);
         error.Metadata.ShouldHaveSingleItem();
-        error.Metadata.Single().ShouldBeEquivalentTo(new KeyValuePair<string, object>("Key", 0));
+        error.Metadata.Single().ShouldBeEquivalentTo(new KeyValuePair<string, object?>("Key", 0));
     }
 
     [Fact]
@@ -1186,7 +1186,7 @@ public sealed class ResultTValueTests
         var error = result.Errors.ShouldHaveSingleItem();
         error.Message.ShouldBe("Sample error message");
         error.Metadata.ShouldHaveSingleItem();
-        error.Metadata.Single().ShouldBeEquivalentTo(new KeyValuePair<string, object>("Key", 0));
+        error.Metadata.Single().ShouldBeEquivalentTo(new KeyValuePair<string, object?>("Key", 0));
     }
 
     [Fact]
@@ -1197,7 +1197,7 @@ public sealed class ResultTValueTests
             where TResult : IActionableResult<TValue, Result<TValue>>
         {
             const string errorMessage = "Sample error message";
-            var metadata = new KeyValuePair<string, object>("Key", 0);
+            var metadata = new KeyValuePair<string, object?>("Key", 0);
             return TResult.Failure(errorMessage, metadata);
         }
 
@@ -1212,7 +1212,7 @@ public sealed class ResultTValueTests
         var error = result.Errors.ShouldHaveSingleItem();
         error.Message.ShouldBe("Sample error message");
         error.Metadata.ShouldHaveSingleItem();
-        error.Metadata.Single().ShouldBeEquivalentTo(new KeyValuePair<string, object>("Key", 0));
+        error.Metadata.Single().ShouldBeEquivalentTo(new KeyValuePair<string, object?>("Key", 0));
     }
 
     [Fact]
@@ -1223,7 +1223,7 @@ public sealed class ResultTValueTests
             where TResult : IActionableResult<TValue, Result<TValue>>
         {
             const string errorMessage = "Sample error message";
-            IReadOnlyDictionary<string, object> metadata = new Dictionary<string, object>
+            IReadOnlyDictionary<string, object?> metadata = new Dictionary<string, object?>
             {
                 { "Key", 0 },
             };
@@ -1241,7 +1241,7 @@ public sealed class ResultTValueTests
         var error = result.Errors.ShouldHaveSingleItem();
         error.Message.ShouldBe("Sample error message");
         error.Metadata.ShouldHaveSingleItem();
-        error.Metadata.Single().ShouldBeEquivalentTo(new KeyValuePair<string, object>("Key", 0));
+        error.Metadata.Single().ShouldBeEquivalentTo(new KeyValuePair<string, object?>("Key", 0));
     }
 
     [Fact]

--- a/tests/LightResults.Tests/ResultTests.cs
+++ b/tests/LightResults.Tests/ResultTests.cs
@@ -186,7 +186,7 @@ public sealed class ResultTests
         singleError.Message.ShouldBe(errorMessage);
 
         singleError.Metadata.Count.ShouldBe(1);
-        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object>("Key", 0));
+        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
     [Fact]
@@ -194,7 +194,7 @@ public sealed class ResultTests
     {
         // Arrange
         const string errorMessage = "Sample error message";
-        var metadata = new KeyValuePair<string, object>("Key", 0);
+        var metadata = new KeyValuePair<string, object?>("Key", 0);
 
         // Act
         var result = Result.Failure(errorMessage, metadata);
@@ -208,7 +208,7 @@ public sealed class ResultTests
         singleError.Message.ShouldBe(errorMessage);
 
         singleError.Metadata.Count.ShouldBe(1);
-        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object>("Key", 0));
+        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
     [Fact]
@@ -216,7 +216,7 @@ public sealed class ResultTests
     {
         // Arrange
         const string errorMessage = "Sample error message";
-        IReadOnlyDictionary<string, object> metadata = new Dictionary<string, object>
+        IReadOnlyDictionary<string, object?> metadata = new Dictionary<string, object?>
         {
             { "Key", 0 },
         };
@@ -233,7 +233,7 @@ public sealed class ResultTests
         singleError.Message.ShouldBe(errorMessage);
 
         singleError.Metadata.Count.ShouldBe(1);
-        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object>("Key", 0));
+        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
     [Fact]
@@ -286,29 +286,46 @@ public sealed class ResultTests
     }
 
     [Fact]
-    public void Failure_WithNullException_ShouldThrow()
+    public void Failure_WithNullException_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
         Exception? exception = null;
 
         // Act
-        Func<object?> act = () => Result.Failure(exception!);
+        var result = Result.Failure(exception);
 
         // Assert
-        Should.Throw<ArgumentNullException>(act);
+        result.IsSuccess().ShouldBeFalse();
+        result.IsFailure().ShouldBeTrue();
+
+        var singleError = result.Errors.ShouldHaveSingleItem();
+        singleError.Message.ShouldBe("");
+        singleError.Metadata.Count.ShouldBe(1);
+        var metadata = singleError.Metadata.Single();
+        metadata.Key.ShouldBe("Exception");
+        metadata.Value.ShouldBe(exception);
     }
 
     [Fact]
-    public void Failure_WithMessageAndNullException_ShouldThrow()
+    public void Failure_WithMessageAndNullException_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
+        const string errorMessage = "Sample error message";
         Exception? exception = null;
 
         // Act
-        Func<object?> act = () => Result.Failure("", exception!);
+        var result = Result.Failure(errorMessage, exception);
 
         // Assert
-        Should.Throw<ArgumentNullException>(act);
+        result.IsSuccess().ShouldBeFalse();
+        result.IsFailure().ShouldBeTrue();
+
+        var singleError = result.Errors.ShouldHaveSingleItem();
+        singleError.Message.ShouldBe(errorMessage);
+        singleError.Metadata.Count.ShouldBe(1);
+        var metadata = singleError.Metadata.Single();
+        metadata.Key.ShouldBe("Exception");
+        metadata.Value.ShouldBe(exception);
     }
 
     [Fact]
@@ -426,7 +443,7 @@ public sealed class ResultTests
         singleError.Message.ShouldBe(errorMessage);
 
         singleError.Metadata.Count.ShouldBe(1);
-        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object>("Key", 0));
+        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
     [Fact]
@@ -434,7 +451,7 @@ public sealed class ResultTests
     {
         // Arrange
         const string errorMessage = "Sample error message";
-        var metadata = new KeyValuePair<string, object>("Key", 0);
+        var metadata = new KeyValuePair<string, object?>("Key", 0);
 
         // Act
         var result = Result.Failure<object>(errorMessage, metadata);
@@ -449,7 +466,7 @@ public sealed class ResultTests
         singleError.Message.ShouldBe(errorMessage);
 
         singleError.Metadata.Count.ShouldBe(1);
-        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object>("Key", 0));
+        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
     [Fact]
@@ -457,7 +474,7 @@ public sealed class ResultTests
     {
         // Arrange
         const string errorMessage = "Sample error message";
-        IReadOnlyDictionary<string, object> metadata = new Dictionary<string, object>
+        IReadOnlyDictionary<string, object?> metadata = new Dictionary<string, object?>
         {
             { "Key", 0 },
         };
@@ -475,7 +492,7 @@ public sealed class ResultTests
         singleError.Message.ShouldBe(errorMessage);
 
         singleError.Metadata.Count.ShouldBe(1);
-        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object>("Key", 0));
+        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
     [Fact]
@@ -528,29 +545,46 @@ public sealed class ResultTests
     }
 
     [Fact]
-    public void FailureTValue_WithNullException_ShouldThrow()
+    public void FailureTValue_WithNullException_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
         Exception? exception = null;
 
         // Act
-        Func<object?> act = () => Result.Failure<object>(exception!);
+        var result = Result.Failure<object>(exception);
 
         // Assert
-        Should.Throw<ArgumentNullException>(act);
+        result.IsSuccess().ShouldBeFalse();
+        result.IsFailure().ShouldBeTrue();
+
+        var singleError = result.Errors.ShouldHaveSingleItem();
+        singleError.Message.ShouldBe("");
+        singleError.Metadata.Count.ShouldBe(1);
+        var metadata = singleError.Metadata.Single();
+        metadata.Key.ShouldBe("Exception");
+        metadata.Value.ShouldBe(exception);
     }
 
     [Fact]
-    public void FailureTValue_WithMessageAndNullException_ShouldThrow()
+    public void FailureTValue_WithMessageAndNullException_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
+        const string errorMessage = "Sample error message";
         Exception? exception = null;
 
         // Act
-        Func<object?> act = () => Result.Failure<object>("", exception!);
+        var result = Result.Failure<object>(errorMessage, exception);
 
         // Assert
-        Should.Throw<ArgumentNullException>(act);
+        result.IsSuccess().ShouldBeFalse();
+        result.IsFailure().ShouldBeTrue();
+
+        var singleError = result.Errors.ShouldHaveSingleItem();
+        singleError.Message.ShouldBe(errorMessage);
+        singleError.Metadata.Count.ShouldBe(1);
+        var metadata = singleError.Metadata.Single();
+        metadata.Key.ShouldBe("Exception");
+        metadata.Value.ShouldBe(exception);
     }
 
     [Fact]
@@ -983,7 +1017,7 @@ public sealed class ResultTests
         singleError.Message.ShouldBe("Sample error message");
 
         singleError.Metadata.Count.ShouldBe(1);
-        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object>("Key", 0));
+        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
     [Fact]
@@ -994,7 +1028,7 @@ public sealed class ResultTests
             where TResult : IActionableResult<Result>
         {
             const string errorMessage = "Sample error message";
-            IReadOnlyDictionary<string, object> metadata = new Dictionary<string, object>
+            IReadOnlyDictionary<string, object?> metadata = new Dictionary<string, object?>
             {
                 { "Key", 0 },
             };
@@ -1013,7 +1047,7 @@ public sealed class ResultTests
         singleError.Message.ShouldBe("Sample error message");
 
         singleError.Metadata.Count.ShouldBe(1);
-        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object>("Key", 0));
+        singleError.Metadata.Single().ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- allow nullable Exception on Result.Failure overloads
- adjust failure handling logic
- update tests for new behaviour
- refactor Error metadata to allow nullable values

## Testing
- `dotnet build LightResults.sln`
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net6.0` *(fails: No test is available)*

------
https://chatgpt.com/codex/tasks/task_e_686d48ce80708328bf62b059878b8f69