### PR TITLE
Update testing instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,12 @@ The project uses the standard .NET SDK.  When a .NET environment is available yo
  dotnet build LightResults.sln
 
 # Run tests
- dotnet test tests/LightResults.Tests/LightResults.Tests.csproj
+ dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net8.0
 ```
+
+The test project targets multiple frameworks. When `Mono` is not available (as
+in the Codex container) the `net481` target fails to start. Specify a supported
+framework like `net8.0` to run the unit tests successfully.
 
 However, building or testing is not required for simple documentation updates.  This repository currently does not include an automated setup script for installing the .NET SDK.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,12 +38,12 @@ The project uses the standard .NET SDK.  When a .NET environment is available yo
  dotnet build LightResults.sln
 
 # Run tests
- dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net8.0
+ dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net9.0
 ```
 
 The test project targets multiple frameworks. When `Mono` is not available (as
 in the Codex container) the `net481` target fails to start. Specify a supported
-framework like `net8.0` to run the unit tests successfully.
+framework like `net9.0` to run the unit tests successfully.
 
 However, building or testing is not required for simple documentation updates.  This repository currently does not include an automated setup script for installing the .NET SDK.
 


### PR DESCRIPTION
## Summary
- mention how to run tests when mono is unavailable in the container

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net8.0 --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686d6f98d9048328b68240f7f0078995