### PR TITLE
Add Exception property to Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,3 +308,4 @@ The following steps in the following order will reduce the amount of manual work
 - New property initializers were added to `Error`.
   - `Message { get; }` has changed to `Message { get; init; }`.
   - `Metadata { get; }` has changed to `Metadata { get; init; }`.
+  - `Exception { get; }` has been added.

--- a/src/LightResults/Error.cs
+++ b/src/LightResults/Error.cs
@@ -11,6 +11,22 @@ public class Error : IError
     /// <inheritdoc/>
     public IReadOnlyDictionary<string, object?> Metadata { get; init; }
 
+    /// <summary>Gets the <see cref="Exception"/> associated with the error if one exists.</summary>
+    /// <returns>
+    /// An <see cref="Exception"/> instance when the metadata contains an entry named
+    /// <c>"Exception"</c> with a value of type <see cref="Exception"/>; otherwise, <see langword="null"/>.
+    /// </returns>
+    public Exception? Exception
+    {
+        get
+        {
+            if (Metadata.TryGetValue("Exception", out var value) && value is Exception ex)
+                return ex;
+
+            return null;
+        }
+    }
+
     internal static IError Empty { get; } = new Error("", new Dictionary<string, object?>());
     internal static IReadOnlyList<IError> EmptyErrorList { get; } = [];
     internal static IReadOnlyList<IError> DefaultErrorList { get; } = [new Error("", new Dictionary<string, object?>())];

--- a/tests/LightResults.Tests/ErrorTests.cs
+++ b/tests/LightResults.Tests/ErrorTests.cs
@@ -155,5 +155,36 @@ public sealed class ErrorTests
         var error = new Error(errorMessage);
 
         // Assert
-        error.ToString().ShouldBe(errorMessage.Length > 0 ? $"Error {{ Message = \"{errorMessage}\" }}" : "Error");
-    }}
+        error.ToString().ShouldBe(errorMessage.Length > 0 ? $"Error {{ Message = \"{errorMessage}\" }}" : "Error");    }
+
+    [Fact]
+    public void ExceptionProperty_ShouldReturnExceptionWhenMetadataContainsException()
+    {
+        // Arrange
+        var exception = new InvalidOperationException();
+        var error = new Error("", ("Exception", exception));
+
+        // Assert
+        error.Exception.ShouldBe(exception);
+    }
+
+    [Fact]
+    public void ExceptionProperty_ShouldReturnNullWhenMetadataDoesNotContainException()
+    {
+        // Arrange
+        var error = new Error();
+
+        // Assert
+        error.Exception.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExceptionProperty_ShouldReturnNullWhenMetadataIsNotException()
+    {
+        // Arrange
+        var error = new Error("", ("Exception", "not exception"));
+
+        // Assert
+        error.Exception.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- expose `Error.Exception` computed property
- document new property in README
- add tests for new property

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net9.0`

------
https://chatgpt.com/codex/tasks/task_e_686d7904c00c8328b15e214b0c0f9233