### PR TITLE
Fix documentation typos

### DIFF
--- a/src/LightResults/IResult.cs
+++ b/src/LightResults/IResult.cs
@@ -13,13 +13,13 @@ public interface IResult
     /// <returns><c>true</c> if the result was successful; otherwise, <c>false</c>.</returns>
     bool IsSuccess();
 
-    /// <summary>Determines whether the result failure.</summary>
-    /// <returns><c>true</c> if the result failure; otherwise, <c>false</c>.</returns>
+    /// <summary>Determines whether the result is a failure.</summary>
+    /// <returns><c>true</c> if the result is a failure; otherwise, <c>false</c>.</returns>
     bool IsFailure();
 
-    /// <summary>Determines whether the result failure.</summary>
+    /// <summary>Determines whether the result is a failure.</summary>
     /// <param name="error">The error of the result.</param>
-    /// <returns><c>true</c> if the result failure; otherwise, <c>false</c>.</returns>
+    /// <returns><c>true</c> if the result is a failure; otherwise, <c>false</c>.</returns>
     bool IsFailure([MaybeNullWhen(false)] out IError error);
 
     /// <summary>Checks if the result contains an error of the specified type.</summary>

--- a/src/LightResults/IResult`1.cs
+++ b/src/LightResults/IResult`1.cs
@@ -11,15 +11,15 @@ public interface IResult<TValue> : IResult
     /// <returns><c>true</c> if the result was successful; otherwise, <c>false</c>.</returns>
     bool IsSuccess([MaybeNullWhen(false)] out TValue value);
 
-    /// <summary>Determines whether the result failure.</summary>
+    /// <summary>Determines whether the result was successful.</summary>
     /// <param name="value">The value of the result.</param>
     /// <param name="error">The error of the result.</param>
     /// <returns><c>true</c> if the result was successful; otherwise, <c>false</c>.</returns>
     bool IsSuccess([MaybeNullWhen(false)] out TValue value, [MaybeNullWhen(true)] out IError error);
 
-    /// <summary>Determines whether the result failure.</summary>
+    /// <summary>Determines whether the result is a failure.</summary>
     /// <param name="error">The error of the result.</param>
     /// <param name="value">The value of the result.</param>
-    /// <returns><c>true</c> if the result failure; otherwise, <c>false</c>.</returns>
+    /// <returns><c>true</c> if the result is a failure; otherwise, <c>false</c>.</returns>
     bool IsFailure([MaybeNullWhen(false)] out IError error, [MaybeNullWhen(true)] out TValue value);
 }


### PR DESCRIPTION
## Summary
- fix grammar of `IsFailure` comments

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net9.0`

------
https://chatgpt.com/codex/tasks/task_e_686d78554fe88328b5b20e07964afd55