### PR TITLE
Share static empty metadata

### DIFF
--- a/src/LightResults/Error.cs
+++ b/src/LightResults/Error.cs
@@ -11,10 +11,10 @@ public class Error : IError
     /// <inheritdoc/>
     public IReadOnlyDictionary<string, object?> Metadata { get; init; }
 
-    internal static IError Empty { get; } = new Error("", new Dictionary<string, object?>());
-    internal static IReadOnlyList<IError> EmptyErrorList { get; } = [];
-    internal static IReadOnlyList<IError> DefaultErrorList { get; } = [new Error("", new Dictionary<string, object?>())];
     private static readonly IReadOnlyDictionary<string, object?> EmptyMetaData = new Dictionary<string, object?>();
+    internal static IError Empty { get; } = new Error(string.Empty, EmptyMetaData);
+    internal static IReadOnlyList<IError> EmptyErrorList { get; } = [];
+    internal static IReadOnlyList<IError> DefaultErrorList { get; } = [Empty];
 
     /// <summary>Initializes a new instance of the <see cref="Error"/> class.</summary>
     public Error()


### PR DESCRIPTION
## Summary
- reuse `EmptyMetaData` for `Error.Empty` and `DefaultErrorList` to reduce allocations

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net9.0`

------
https://chatgpt.com/codex/tasks/task_e_686d7f9f169c8328892add17a8fe4897