### PR TITLE
Use HashCode.Combine in Result.GetHashCode

### DIFF
--- a/src/LightResults/Result.cs
+++ b/src/LightResults/Result.cs
@@ -429,7 +429,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <returns>A 32-bit signed integer hash code.</returns>
     public override int GetHashCode()
     {
-        return _errors?.GetHashCode() ?? 0;
+        return HashCode.Combine(_errors);
     }
 
     /// <summary>Determines whether two <see cref="Result"/> instances are equal.</summary>


### PR DESCRIPTION
## Summary
- improve hash code distribution for `Result` by delegating to `HashCode.Combine`

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net9.0`

------
https://chatgpt.com/codex/tasks/task_e_686d806863bc8328b534b61897ca9794