### PR TITLE
Expose Error.Empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ if (result.IsSuccess(out var value))
 Errors can be created with or without a message.
 
 ```csharp
+var emptyError = Error.Empty;
+
 var errorWithoutMessage = new Error();
 
 var errorWithMessage = new Error("Something went wrong!");
@@ -308,3 +310,4 @@ The following steps in the following order will reduce the amount of manual work
 - New property initializers were added to `Error`.
   - `Message { get; }` has changed to `Message { get; init; }`.
   - `Metadata { get; }` has changed to `Metadata { get; init; }`.
+  - `Error.Empty` is now publicly accessible.

--- a/src/LightResults/Error.cs
+++ b/src/LightResults/Error.cs
@@ -11,7 +11,8 @@ public class Error : IError
     /// <inheritdoc/>
     public IReadOnlyDictionary<string, object?> Metadata { get; init; }
 
-    internal static IError Empty { get; } = new Error("", new Dictionary<string, object?>());
+    /// <summary>Gets an empty <see cref="Error"/> instance.</summary>
+    public static IError Empty { get; } = new Error("", new Dictionary<string, object?>());
     internal static IReadOnlyList<IError> EmptyErrorList { get; } = [];
     internal static IReadOnlyList<IError> DefaultErrorList { get; } = [new Error("", new Dictionary<string, object?>())];
     private static readonly IReadOnlyDictionary<string, object?> EmptyMetaData = new Dictionary<string, object?>();

--- a/tests/LightResults.Tests/ResultTValueTests.cs
+++ b/tests/LightResults.Tests/ResultTValueTests.cs
@@ -9,7 +9,7 @@ namespace LightResults.Tests;
 
 public sealed class ResultTValueTests
 {
-    private static readonly Error EmptyError = new();
+    private static readonly IError EmptyError = Error.Empty;
 
     [Fact]
     public void DefaultStruct_ShouldBeFailureResultWithDefaultValue()

--- a/tests/LightResults.Tests/ResultTests.cs
+++ b/tests/LightResults.Tests/ResultTests.cs
@@ -7,7 +7,7 @@ namespace LightResults.Tests;
 
 public sealed class ResultTests
 {
-    private static readonly Error EmptyError = new();
+    private static readonly IError EmptyError = Error.Empty;
 
     [Fact]
     public void DefaultStruct_ShouldBeFailureResult()


### PR DESCRIPTION
## Summary
- expose `Error.Empty` publicly
- document the new `Error.Empty` property
- update tests to use public `Error.Empty`

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net9.0`

------
https://chatgpt.com/codex/tasks/task_e_686d801800a483288acc7ec55f99dbc0