### PR TITLE
Optimize Error.ToString

### DIFF
--- a/src/LightResults/Error.cs
+++ b/src/LightResults/Error.cs
@@ -15,6 +15,7 @@ public class Error : IError
     internal static IReadOnlyList<IError> EmptyErrorList { get; } = [];
     internal static IReadOnlyList<IError> DefaultErrorList { get; } = [new Error("", new Dictionary<string, object?>())];
     private static readonly IReadOnlyDictionary<string, object?> EmptyMetaData = new Dictionary<string, object?>();
+    private const string ErrorTypeName = nameof(Error);
 
     /// <summary>Initializes a new instance of the <see cref="Error"/> class.</summary>
     public Error()
@@ -77,8 +78,10 @@ public class Error : IError
     /// <inheritdoc/>
     public override string ToString()
     {
-        var errorType = GetType()
-            .Name;
+        var type = GetType();
+        var errorType = type == typeof(Error)
+            ? ErrorTypeName
+            : type.Name;
 
         if (Message.Length == 0)
             return errorType;


### PR DESCRIPTION
## Summary
- reduce reflection in `Error.ToString` by using a cached constant name when the runtime type is `Error`

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net9.0`

------
https://chatgpt.com/codex/tasks/task_e_686d811a65a08328b1e4cf4a125d3d2c