### PR TITLE
Optimize result equality

### DIFF
--- a/src/LightResults/Result.cs
+++ b/src/LightResults/Result.cs
@@ -412,9 +412,14 @@ public readonly struct Result : IEquatable<Result>,
     /// <summary>Determines whether two <see cref="Result"/> instances are equal.</summary>
     /// <param name="other">The <see cref="Result"/> instance to compare with this instance.</param>
     /// <returns><c>true</c> if the specified <see cref="Result"/> is equal to this instance; otherwise, <c>false</c>.</returns>
-    public bool Equals(Result other)
+    public bool Equals(in Result other)
     {
         return Equals(_errors, other._errors);
+    }
+
+    bool IEquatable<Result>.Equals(Result other)
+    {
+        return Equals(in other);
     }
 
     /// <summary>Determines whether the specified object is equal to this instance.</summary>
@@ -422,7 +427,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <returns><c>true</c> if the specified object is equal to this instance; otherwise, <c>false</c>.</returns>
     public override bool Equals(object? obj)
     {
-        return obj is Result other && Equals(other);
+        return obj is Result other && Equals(in other);
     }
 
     /// <summary>Returns the hash code for this instance.</summary>
@@ -436,18 +441,18 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="left">The first <see cref="Result"/> instance to compare.</param>
     /// <param name="right">The second <see cref="Result"/> instance to compare.</param>
     /// <returns><c>true</c> if the specified <see cref="Result"/> instances are equal; otherwise, <c>false</c>.</returns>
-    public static bool operator ==(Result left, Result right)
+    public static bool operator ==(in Result left, in Result right)
     {
-        return left.Equals(right);
+        return left.Equals(in right);
     }
 
     /// <summary>Determines whether two <see cref="Result"/> instances are not equal.</summary>
     /// <param name="left">The first <see cref="Result"/> instance to compare.</param>
     /// <param name="right">The second <see cref="Result"/> instance to compare.</param>
     /// <returns><c>true</c> if the specified <see cref="Result"/> instances are not equal; otherwise, <c>false</c>.</returns>
-    public static bool operator !=(Result left, Result right)
+    public static bool operator !=(in Result left, in Result right)
     {
-        return !left.Equals(right);
+        return !left.Equals(in right);
     }
 
     /// <inheritdoc/>

--- a/src/LightResults/Result`1.cs
+++ b/src/LightResults/Result`1.cs
@@ -311,9 +311,14 @@ static Result<TValue> IActionableResult<TValue, Result<TValue>>.Failure(string e
     /// <summary>Determines whether two <see cref="Result{TValue}"/> instances are equal.</summary>
     /// <param name="other">The <see cref="Result{TValue}"/> instance to compare with this instance.</param>
     /// <returns><c>true</c> if the specified <see cref="Result{TValue}"/> is equal to this instance; otherwise, <c>false</c>.</returns>
-    public bool Equals(Result<TValue> other)
+    public bool Equals(in Result<TValue> other)
     {
         return Equals(_errors, other._errors) && EqualityComparer<TValue?>.Default.Equals(_valueOrDefault, other._valueOrDefault);
+    }
+
+    bool IEquatable<Result<TValue>>.Equals(Result<TValue> other)
+    {
+        return Equals(in other);
     }
 
     /// <summary>Determines whether the specified object is equal to this instance.</summary>
@@ -321,7 +326,7 @@ static Result<TValue> IActionableResult<TValue, Result<TValue>>.Failure(string e
     /// <returns><c>true</c> if the specified object is equal to this instance; otherwise, <c>false</c>.</returns>
     public override bool Equals(object? obj)
     {
-        return obj is Result<TValue> other && Equals(other);
+        return obj is Result<TValue> other && Equals(in other);
     }
 
     /// <summary>Returns the hash code for this instance.</summary>
@@ -335,18 +340,18 @@ static Result<TValue> IActionableResult<TValue, Result<TValue>>.Failure(string e
     /// <param name="left">The first <see cref="Result{TValue}"/> instance to compare.</param>
     /// <param name="right">The second <see cref="Result{TValue}"/> instance to compare.</param>
     /// <returns><c>true</c> if the specified <see cref="Result{TValue}"/> instances are equal; otherwise, <c>false</c>.</returns>
-    public static bool operator ==(Result<TValue> left, Result<TValue> right)
+    public static bool operator ==(in Result<TValue> left, in Result<TValue> right)
     {
-        return left.Equals(right);
+        return left.Equals(in right);
     }
 
     /// <summary>Determines whether two <see cref="Result{TValue}"/> instances are not equal.</summary>
     /// <param name="left">The first <see cref="Result{TValue}"/> instance to compare.</param>
     /// <param name="right">The second <see cref="Result{TValue}"/> instance to compare.</param>
     /// <returns><c>true</c> if the specified <see cref="Result{TValue}"/> instances are not equal; otherwise, <c>false</c>.</returns>
-    public static bool operator !=(Result<TValue> left, Result<TValue> right)
+    public static bool operator !=(in Result<TValue> left, in Result<TValue> right)
     {
-        return !left.Equals(right);
+        return !left.Equals(in right);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Summary
- reduce copies when comparing Result structs by passing parameters as `in`

## Testing
- `dotnet build LightResults.sln`
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net9.0`


------
https://chatgpt.com/codex/tasks/task_e_686d813a77988328876d2bdcbfb284a7