### PR TITLE
Improve small metadata allocations

### DIFF
--- a/src/LightResults/Common/SingleItemReadOnlyDictionary.cs
+++ b/src/LightResults/Common/SingleItemReadOnlyDictionary.cs
@@ -1,0 +1,157 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace LightResults.Common;
+
+/// <summary>
+/// A minimal read-only dictionary optimized for a single key/value pair.
+/// </summary>
+/// <typeparam name="TKey">Dictionary key type.</typeparam>
+/// <typeparam name="TValue">Dictionary value type.</typeparam>
+internal sealed class SingleItemReadOnlyDictionary<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
+    where TKey : notnull
+{
+    private readonly TKey _key;
+    private readonly TValue _value;
+
+    public SingleItemReadOnlyDictionary(TKey key, TValue value)
+    {
+        _key = key;
+        _value = value;
+    }
+
+    public TValue this[TKey key] => EqualityComparer<TKey>.Default.Equals(key, _key)
+        ? _value
+        : throw new KeyNotFoundException();
+
+    public int Count => 1;
+
+    public bool ContainsKey(TKey key) => EqualityComparer<TKey>.Default.Equals(key, _key);
+
+    public bool TryGetValue(TKey key, out TValue value)
+    {
+        if (ContainsKey(key))
+        {
+            value = _value;
+            return true;
+        }
+
+        value = default!;
+        return false;
+    }
+
+    public Enumerator GetEnumerator() => new(_key, _value);
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => GetEnumerator();
+
+    IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => new KeyEnumerable(_key);
+
+    IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => new ValueEnumerable(_value);
+
+    internal struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>
+    {
+        private readonly KeyValuePair<TKey, TValue> _pair;
+        private bool _moved;
+
+        public Enumerator(TKey key, TValue value)
+        {
+            _pair = new KeyValuePair<TKey, TValue>(key, value);
+            _moved = false;
+        }
+
+        public KeyValuePair<TKey, TValue> Current => _pair;
+
+        object IEnumerator.Current => _pair;
+
+        public bool MoveNext()
+        {
+            if (_moved)
+                return false;
+
+            _moved = true;
+            return true;
+        }
+
+        public void Reset() => _moved = false;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private struct KeyEnumerable : IEnumerable<TKey>, IEnumerator<TKey>
+    {
+        private readonly TKey _key;
+        private bool _moved;
+
+        public KeyEnumerable(TKey key)
+        {
+            _key = key;
+            _moved = false;
+        }
+
+        public KeyEnumerable GetEnumerator() => this;
+
+        IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator() => this;
+
+        IEnumerator IEnumerable.GetEnumerator() => this;
+
+        public TKey Current => _key;
+
+        object IEnumerator.Current => _key!;
+
+        public bool MoveNext()
+        {
+            if (_moved)
+                return false;
+
+            _moved = true;
+            return true;
+        }
+
+        public void Reset() => _moved = false;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private struct ValueEnumerable : IEnumerable<TValue>, IEnumerator<TValue>
+    {
+        private readonly TValue _value;
+        private bool _moved;
+
+        public ValueEnumerable(TValue value)
+        {
+            _value = value;
+            _moved = false;
+        }
+
+        public ValueEnumerable GetEnumerator() => this;
+
+        IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator() => this;
+
+        IEnumerator IEnumerable.GetEnumerator() => this;
+
+        public TValue Current => _value;
+
+        object IEnumerator.Current => _value!;
+
+        public bool MoveNext()
+        {
+            if (_moved)
+                return false;
+
+            _moved = true;
+            return true;
+        }
+
+        public void Reset() => _moved = false;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/LightResults/Error.cs
+++ b/src/LightResults/Error.cs
@@ -36,10 +36,7 @@ public class Error : IError
     public Error(string message, (string Key, object? Value) metadata)
     {
         Message = message;
-        Metadata = new Dictionary<string, object?>(1)
-        {
-            { metadata.Key, metadata.Value },
-        };
+        Metadata = new SingleItemReadOnlyDictionary<string, object?>(metadata.Key, metadata.Value);
     }
 
     /// <summary>Initializes a new instance of the <see cref="Error"/> class with the specified error message and metadata.</summary>
@@ -48,10 +45,7 @@ public class Error : IError
     public Error(string message, KeyValuePair<string, object?> metadata)
     {
         Message = message;
-        Metadata = new Dictionary<string, object?>(1)
-        {
-            { metadata.Key, metadata.Value },
-        };
+        Metadata = new SingleItemReadOnlyDictionary<string, object?>(metadata.Key, metadata.Value);
     }
 
 #if NET6_0_OR_GREATER

--- a/src/LightResults/Result.cs
+++ b/src/LightResults/Result.cs
@@ -95,10 +95,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified error message and metadata.</returns>
     public static Result Failure(string errorMessage, (string Key, object? Value) metadata)
     {
-        var dictionary = new Dictionary<string, object?>(1)
-        {
-            { metadata.Key, metadata.Value },
-        };
+        var dictionary = new SingleItemReadOnlyDictionary<string, object?>(metadata.Key, metadata.Value);
         var error = new Error(errorMessage, dictionary);
         return new Result(error);
     }
@@ -109,10 +106,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified error message and metadata.</returns>
     public static Result Failure(string errorMessage, KeyValuePair<string, object?> metadata)
     {
-        var dictionary = new Dictionary<string, object?>(1)
-        {
-            { metadata.Key, metadata.Value },
-        };
+        var dictionary = new SingleItemReadOnlyDictionary<string, object?>(metadata.Key, metadata.Value);
         var error = new Error(errorMessage, dictionary);
         return new Result(error);
     }
@@ -136,10 +130,7 @@ public readonly struct Result : IEquatable<Result>,
     /// </remarks>
     public static Result Failure(Exception? ex)
     {
-        var metadata = new Dictionary<string, object?>(1)
-        {
-            { "Exception", ex },
-        };
+        var metadata = new SingleItemReadOnlyDictionary<string, object?>("Exception", ex);
         var message = ex?.Message ?? string.Empty;
         var error = new Error(message, metadata);
         return new Result(error);
@@ -152,10 +143,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <remarks>The exception is added to the error <see cref="Error.Metadata"/> under the key of "Exception".</remarks>
     public static Result Failure(string errorMessage, Exception? ex)
     {
-        var metadata = new Dictionary<string, object?>(1)
-        {
-            { "Exception", ex },
-        };
+        var metadata = new SingleItemReadOnlyDictionary<string, object?>("Exception", ex);
         var error = new Error(errorMessage, metadata);
         return new Result(error);
     }
@@ -209,10 +197,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message and metadata.</returns>
     public static Result<TValue> Failure<TValue>(string errorMessage, (string Key, object? Value) metadata)
     {
-        var dictionary = new Dictionary<string, object?>(1)
-        {
-            { metadata.Key, metadata.Value },
-        };
+        var dictionary = new SingleItemReadOnlyDictionary<string, object?>(metadata.Key, metadata.Value);
         var error = new Error(errorMessage, dictionary);
         return new Result<TValue>(error);
     }
@@ -224,10 +209,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message and metadata.</returns>
     public static Result<TValue> Failure<TValue>(string errorMessage, KeyValuePair<string, object?> metadata)
     {
-        var dictionary = new Dictionary<string, object?>(1)
-        {
-            { metadata.Key, metadata.Value },
-        };
+        var dictionary = new SingleItemReadOnlyDictionary<string, object?>(metadata.Key, metadata.Value);
         var error = new Error(errorMessage, dictionary);
         return new Result<TValue>(error);
     }
@@ -252,10 +234,7 @@ public readonly struct Result : IEquatable<Result>,
     /// </remarks>
     public static Result<TValue> Failure<TValue>(Exception? ex)
     {
-        var metadata = new Dictionary<string, object?>(1)
-        {
-            { "Exception", ex },
-        };
+        var metadata = new SingleItemReadOnlyDictionary<string, object?>("Exception", ex);
         var message = ex?.Message ?? string.Empty;
         var error = new Error(message, metadata);
         return new Result<TValue>(error);
@@ -268,10 +247,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <remarks>The exception is added to the error <see cref="Error.Metadata"/> under the key of "Exception".</remarks>
     public static Result<TValue> Failure<TValue>(string errorMessage, Exception? ex)
     {
-        var metadata = new Dictionary<string, object?>(1)
-        {
-            { "Exception", ex },
-        };
+        var metadata = new SingleItemReadOnlyDictionary<string, object?>("Exception", ex);
         var error = new Error(errorMessage, metadata);
         return new Result<TValue>(error);
     }

--- a/src/LightResults/Result`1.cs
+++ b/src/LightResults/Result`1.cs
@@ -157,10 +157,7 @@ public readonly struct Result<TValue> : IEquatable<Result<TValue>>,
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message.</returns>
 static Result<TValue> IActionableResult<TValue, Result<TValue>>.Failure(string errorMessage, (string Key, object? Value) metadata)
 {
-    var dictionary = new Dictionary<string, object?>(1)
-    {
-        { metadata.Key, metadata.Value },
-    };
+    var dictionary = new SingleItemReadOnlyDictionary<string, object?>(metadata.Key, metadata.Value);
         var error = new Error(errorMessage, dictionary);
         return new Result<TValue>(error);
     }
@@ -171,10 +168,7 @@ static Result<TValue> IActionableResult<TValue, Result<TValue>>.Failure(string e
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message.</returns>
 static Result<TValue> IActionableResult<TValue, Result<TValue>>.Failure(string errorMessage, KeyValuePair<string, object?> metadata)
 {
-    var dictionary = new Dictionary<string, object?>(1)
-    {
-        { metadata.Key, metadata.Value },
-    };
+    var dictionary = new SingleItemReadOnlyDictionary<string, object?>(metadata.Key, metadata.Value);
         var error = new Error(errorMessage, dictionary);
         return new Result<TValue>(error);
     }


### PR DESCRIPTION
## Summary
- add `SingleItemReadOnlyDictionary` optimized for single key/value pairs
- use the new dictionary in `Error` constructors
- apply it to `Result` and `Result<TValue>` helpers

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net9.0`

------
https://chatgpt.com/codex/tasks/task_e_686d7fa9151883289e8b57da6661129e