### PR TITLE
Implement equality for Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,20 @@ public sealed class HttpError : Error
 }
 ```
 
+### Comparing errors
+
+`Error` implements `IEquatable<Error>` so instances with the same message and metadata are considered equal.
+
+```csharp
+var error1 = new Error("Invalid", ("Code", 42));
+var error2 = new Error("Invalid", ("Code", 42));
+
+if (error1 == error2)
+{
+    // Errors are equal
+}
+```
+
 We can further simplify creating errors by creating an error factory.
 
 ```csharp

--- a/src/LightResults/Error.cs
+++ b/src/LightResults/Error.cs
@@ -1,9 +1,10 @@
-﻿using LightResults.Common;
+using System;
+using LightResults.Common;
 
 namespace LightResults;
 
 /// <summary>Represents an error with a message and associated metadata.</summary>
-public class Error : IError
+public class Error : IError, IEquatable<Error>
 {
     /// <inheritdoc/>
     public string Message { get; init; }
@@ -72,6 +73,78 @@ public class Error : IError
     {
         Message = message;
         Metadata = metadata;
+    }
+
+    /// <summary>Determines whether the specified <see cref="Error"/> is equal to this instance.</summary>
+    /// <param name="other">The <see cref="Error"/> to compare with this instance.</param>
+    /// <returns><c>true</c> if the specified <see cref="Error"/> is equal to this instance; otherwise, <c>false</c>.</returns>
+    public bool Equals(Error? other)
+    {
+        if (ReferenceEquals(null, other))
+            return false;
+
+        if (ReferenceEquals(this, other))
+            return true;
+
+        if (!Message.Equals(other.Message, StringComparison.Ordinal))
+            return false;
+
+        if (Metadata.Count != other.Metadata.Count)
+            return false;
+
+        foreach (var kvp in Metadata)
+        {
+            if (!other.Metadata.TryGetValue(kvp.Key, out var otherValue))
+                return false;
+
+            if (!Equals(kvp.Value, otherValue))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj)
+    {
+        return obj is Error other && Equals(other);
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Message, StringComparer.Ordinal);
+
+        var metadataHash = 0;
+        foreach (var kvp in Metadata)
+        {
+            metadataHash ^= HashCode.Combine(kvp.Key, kvp.Value);
+        }
+
+        hash.Add(metadataHash);
+        return hash.ToHashCode();
+    }
+
+    /// <summary>Determines whether two <see cref="Error"/> instances are equal.</summary>
+    /// <param name="left">The first <see cref="Error"/> instance to compare.</param>
+    /// <param name="right">The second <see cref="Error"/> instance to compare.</param>
+    /// <returns><c>true</c> if the specified <see cref="Error"/> instances are equal; otherwise, <c>false</c>.</returns>
+    public static bool operator ==(Error? left, Error? right)
+    {
+        if (left is null)
+            return right is null;
+
+        return left.Equals(right);
+    }
+
+    /// <summary>Determines whether two <see cref="Error"/> instances are not equal.</summary>
+    /// <param name="left">The first <see cref="Error"/> instance to compare.</param>
+    /// <param name="right">The second <see cref="Error"/> instance to compare.</param>
+    /// <returns><c>true</c> if the specified <see cref="Error"/> instances are not equal; otherwise, <c>false</c>.</returns>
+    public static bool operator !=(Error? left, Error? right)
+    {
+        return !(left == right);
     }
 
     /// <inheritdoc/>

--- a/tests/LightResults.Tests/ErrorTests.cs
+++ b/tests/LightResults.Tests/ErrorTests.cs
@@ -155,5 +155,104 @@ public sealed class ErrorTests
         var error = new Error(errorMessage);
 
         // Assert
-        error.ToString().ShouldBe(errorMessage.Length > 0 ? $"Error {{ Message = \"{errorMessage}\" }}" : "Error");
-    }}
+        error.ToString().ShouldBe(errorMessage.Length > 0 ? $"Error {{ Message = \"{errorMessage}\" }}" : "Error");    }
+
+    [Fact]
+    public void Equals_Error_ShouldReturnTrueForEqualErrors()
+    {
+        // Arrange
+        var error1 = new Error("error", ("Key", 1));
+        var error2 = new Error("error", ("Key", 1));
+
+        // Assert
+        error1.Equals(error2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_Error_ShouldReturnFalseForUnequalErrors()
+    {
+        // Arrange
+        var error1 = new Error("error", ("Key", 1));
+        var error2 = new Error("error", ("Key", 2));
+
+        // Assert
+        error1.Equals(error2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_Object_ShouldReturnTrueForEqualErrors()
+    {
+        // Arrange
+        var error1 = new Error("error", ("Key", 1));
+        var error2 = new Error("error", ("Key", 1));
+
+        // Assert
+        error1.Equals((object)error2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_Object_ShouldReturnFalseForUnequalErrors()
+    {
+        // Arrange
+        var error1 = new Error("error", ("Key", 1));
+        var error2 = new Error("error", ("Key", 2));
+
+        // Assert
+        error1.Equals((object)error2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetHashCode_ShouldReturnSameHashCodeForEqualErrors()
+    {
+        // Arrange
+        var error1 = new Error("error", ("Key", 1));
+        var error2 = new Error("error", ("Key", 1));
+
+        // Assert
+        error1.GetHashCode().ShouldBe(error2.GetHashCode());
+    }
+
+    [Fact]
+    public void op_Equality_Error_ShouldReturnTrueForEqualErrors()
+    {
+        // Arrange
+        var error1 = new Error("error", ("Key", 1));
+        var error2 = new Error("error", ("Key", 1));
+
+        // Assert
+        (error1 == error2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void op_Equality_Error_ShouldReturnFalseForUnequalErrors()
+    {
+        // Arrange
+        var error1 = new Error("error", ("Key", 1));
+        var error2 = new Error("error", ("Key", 2));
+
+        // Assert
+        (error1 == error2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void op_Inequality_Error_ShouldReturnFalseForEqualErrors()
+    {
+        // Arrange
+        var error1 = new Error("error", ("Key", 1));
+        var error2 = new Error("error", ("Key", 1));
+
+        // Assert
+        (error1 != error2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void op_Inequality_Error_ShouldReturnTrueForUnequalErrors()
+    {
+        // Arrange
+        var error1 = new Error("error", ("Key", 1));
+        var error2 = new Error("error", ("Key", 2));
+
+        // Assert
+        (error1 != error2).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- implement `IEquatable<Error>` and add equality members
- document comparing errors in README
- add unit tests for new equality semantics

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net9.0`

------
https://chatgpt.com/codex/tasks/task_e_686d7fdaa93c8328bb4a3c54a95770cb