### PR TITLE
Add error constructors for exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ var errorWithMetadataTuple = new Error("Something went wrong!", ("Key", "Value")
 
 var metadata = new Dictionary<string, object> { { "Key", "Value" } };
 var errorWithMetadataDictionary = new Error("Something went wrong!", metadata);
+
+var ex = new InvalidOperationException();
+var errorWithException = new Error(ex);
+
+var errorWithMessageAndException = new Error("Something went wrong!", ex);
 ```
 
 ### Custom errors
@@ -308,3 +313,5 @@ The following steps in the following order will reduce the amount of manual work
 - New property initializers were added to `Error`.
   - `Message { get; }` has changed to `Message { get; init; }`.
   - `Metadata { get; }` has changed to `Metadata { get; init; }`.
+  - `Error(Exception exception)` has been added.
+  - `Error(string message, Exception exception)` has been added.

--- a/src/LightResults/Error.cs
+++ b/src/LightResults/Error.cs
@@ -30,6 +30,34 @@ public class Error : IError
         Metadata = EmptyMetaData;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="Error"/> class with the specified exception.</summary>
+    /// <param name="exception">The <see cref="Exception"/> associated with the error.</param>
+    /// <remarks>
+    /// The <paramref name="exception"/> is added to <see cref="Metadata"/> under the key of
+    /// "Exception" and the <see cref="Message"/> is set to the exception message if present.
+    /// </remarks>
+    public Error(Exception? exception)
+    {
+        Message = exception?.Message ?? string.Empty;
+        Metadata = new Dictionary<string, object?>(1)
+        {
+            { "Exception", exception },
+        };
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="Error"/> class with the specified error message and exception.</summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="exception">The <see cref="Exception"/> associated with the error.</param>
+    /// <remarks>The <paramref name="exception"/> is added to <see cref="Metadata"/> under the key of "Exception".</remarks>
+    public Error(string message, Exception? exception)
+    {
+        Message = message;
+        Metadata = new Dictionary<string, object?>(1)
+        {
+            { "Exception", exception },
+        };
+    }
+
     /// <summary>Initializes a new instance of the <see cref="Error"/> class with the specified error message and metadata.</summary>
     /// <param name="message">The error message.</param>
     /// <param name="metadata">The metadata associated with the error.</param>

--- a/src/LightResults/Result.cs
+++ b/src/LightResults/Result.cs
@@ -136,12 +136,7 @@ public readonly struct Result : IEquatable<Result>,
     /// </remarks>
     public static Result Failure(Exception? ex)
     {
-        var metadata = new Dictionary<string, object?>(1)
-        {
-            { "Exception", ex },
-        };
-        var message = ex?.Message ?? string.Empty;
-        var error = new Error(message, metadata);
+        var error = new Error(ex);
         return new Result(error);
     }
 
@@ -152,11 +147,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <remarks>The exception is added to the error <see cref="Error.Metadata"/> under the key of "Exception".</remarks>
     public static Result Failure(string errorMessage, Exception? ex)
     {
-        var metadata = new Dictionary<string, object?>(1)
-        {
-            { "Exception", ex },
-        };
-        var error = new Error(errorMessage, metadata);
+        var error = new Error(errorMessage, ex);
         return new Result(error);
     }
 
@@ -252,12 +243,7 @@ public readonly struct Result : IEquatable<Result>,
     /// </remarks>
     public static Result<TValue> Failure<TValue>(Exception? ex)
     {
-        var metadata = new Dictionary<string, object?>(1)
-        {
-            { "Exception", ex },
-        };
-        var message = ex?.Message ?? string.Empty;
-        var error = new Error(message, metadata);
+        var error = new Error(ex);
         return new Result<TValue>(error);
     }
 
@@ -268,11 +254,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <remarks>The exception is added to the error <see cref="Error.Metadata"/> under the key of "Exception".</remarks>
     public static Result<TValue> Failure<TValue>(string errorMessage, Exception? ex)
     {
-        var metadata = new Dictionary<string, object?>(1)
-        {
-            { "Exception", ex },
-        };
-        var error = new Error(errorMessage, metadata);
+        var error = new Error(errorMessage, ex);
         return new Result<TValue>(error);
     }
 

--- a/tests/LightResults.Tests/ErrorTests.cs
+++ b/tests/LightResults.Tests/ErrorTests.cs
@@ -146,6 +146,41 @@ public sealed class ErrorTests
         error.Metadata.ShouldBe(metadata);
     }
 
+    [Fact]
+    public void ConstructorWithException_ShouldCreateErrorWithMessageAndMetadata()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("ex message");
+
+        // Act
+        var error = new Error(exception);
+
+        // Assert
+        error.Message.ShouldBe(exception.Message);
+        error.Metadata.Count.ShouldBe(1);
+        var metadata = error.Metadata.Single();
+        metadata.Key.ShouldBe("Exception");
+        metadata.Value.ShouldBe(exception);
+    }
+
+    [Fact]
+    public void ConstructorWithMessageAndException_ShouldCreateErrorWithMessageAndMetadata()
+    {
+        // Arrange
+        const string errorMessage = "Sample error message";
+        var exception = new InvalidOperationException("ex message");
+
+        // Act
+        var error = new Error(errorMessage, exception);
+
+        // Assert
+        error.Message.ShouldBe(errorMessage);
+        error.Metadata.Count.ShouldBe(1);
+        var metadata = error.Metadata.Single();
+        metadata.Key.ShouldBe("Exception");
+        metadata.Value.ShouldBe(exception);
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData("An unknown error occurred!")]
@@ -155,5 +190,5 @@ public sealed class ErrorTests
         var error = new Error(errorMessage);
 
         // Assert
-        error.ToString().ShouldBe(errorMessage.Length > 0 ? $"Error {{ Message = \"{errorMessage}\" }}" : "Error");
-    }}
+        error.ToString().ShouldBe(errorMessage.Length > 0 ? $"Error {{ Message = \"{errorMessage}\" }}" : "Error");    }
+}


### PR DESCRIPTION
## Summary
- expose `Error` constructors that accept exceptions
- simplify `Result.Failure` methods to use new constructors
- document how to create errors from exceptions
- add unit tests for the new constructors

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net9.0`

------
https://chatgpt.com/codex/tasks/task_e_686d800b880c8328972e60e60e9fcaa9