### PR TITLE
Improve test coverage for equality and IActionableResult

### DIFF
--- a/tests/LightResults.Tests/ActionableResultEdgeTests.cs
+++ b/tests/LightResults.Tests/ActionableResultEdgeTests.cs
@@ -1,0 +1,100 @@
+#if NET7_0_OR_GREATER
+using LightResults;
+using LightResults.Common;
+using Shouldly;
+
+namespace LightResults.Tests;
+
+public sealed class ActionableResultEdgeTests
+{
+    private readonly struct CustomResult : IActionableResult<CustomResult>
+    {
+        private readonly Result _inner;
+
+        private CustomResult(Result inner)
+        {
+            _inner = inner;
+        }
+
+        public static CustomResult Success()
+        {
+            return new CustomResult(Result.Success());
+        }
+
+        public static CustomResult Failure()
+        {
+            return new CustomResult(Result.Failure());
+        }
+
+        public static CustomResult Failure(string errorMessage)
+        {
+            return new CustomResult(Result.Failure(errorMessage));
+        }
+
+        public static CustomResult Failure(string errorMessage, (string Key, object? Value) metadata)
+        {
+            return new CustomResult(Result.Failure(errorMessage, metadata));
+        }
+
+        public static CustomResult Failure(string errorMessage, KeyValuePair<string, object?> metadata)
+        {
+            return new CustomResult(Result.Failure(errorMessage, metadata));
+        }
+
+        public static CustomResult Failure(string errorMessage, IReadOnlyDictionary<string, object?> metadata)
+        {
+            return new CustomResult(Result.Failure(errorMessage, metadata));
+        }
+
+        public static CustomResult Failure(IError error)
+        {
+            return new CustomResult(Result.Failure(error));
+        }
+
+        public static CustomResult Failure(IEnumerable<IError> errors)
+        {
+            return new CustomResult(Result.Failure(errors));
+        }
+
+        public static CustomResult Failure(IReadOnlyList<IError> errors)
+        {
+            return new CustomResult(Result.Failure(errors));
+        }
+
+        public IReadOnlyCollection<IError> Errors => _inner.Errors;
+
+        public bool IsSuccess() => _inner.IsSuccess();
+
+        public bool IsFailure() => _inner.IsFailure();
+
+        public bool IsFailure(out IError error) => _inner.IsFailure(out error);
+
+        public bool HasError<TError>() where TError : IError => _inner.HasError<TError>();
+
+        public bool HasError<TError>(out TError error) where TError : IError => _inner.HasError(out error);
+    }
+
+    [Fact]
+    public void CustomActionableResult_Success_ShouldCreateSuccessResult()
+    {
+        // Act
+        var result = CustomResult.Success();
+
+        // Assert
+        result.IsSuccess().ShouldBeTrue();
+        result.IsFailure().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CustomActionableResult_Failure_ShouldCreateFailureResult()
+    {
+        // Act
+        var result = CustomResult.Failure();
+
+        // Assert
+        result.IsSuccess().ShouldBeFalse();
+        result.IsFailure().ShouldBeTrue();
+        result.Errors.ShouldHaveSingleItem();
+    }
+}
+#endif

--- a/tests/LightResults.Tests/ResultTValueTests.cs
+++ b/tests/LightResults.Tests/ResultTValueTests.cs
@@ -852,6 +852,50 @@ public sealed class ResultTValueTests
         (result1 != result2).ShouldBeTrue();
     }
 
+    [Fact]
+    public void Equals_Result_DefaultResults_ShouldReturnTrue()
+    {
+        // Arrange
+        Result<int> result1 = default;
+        Result<int> result2 = default;
+
+        // Assert
+        result1.Equals(result2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetHashCode_Result_DefaultResults_ShouldReturnSameHashCode()
+    {
+        // Arrange
+        Result<int> result1 = default;
+        Result<int> result2 = default;
+
+        // Assert
+        result1.GetHashCode().ShouldBe(result2.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_Result_DefaultAndFailure_ShouldReturnFalse()
+    {
+        // Arrange
+        Result<int> result1 = default;
+        var result2 = Result.Failure<int>();
+
+        // Assert
+        result1.Equals(result2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetHashCode_Result_DefaultAndFailure_ShouldReturnDifferentHashCodes()
+    {
+        // Arrange
+        Result<int> result1 = default;
+        var result2 = Result.Failure<int>();
+
+        // Assert
+        result1.GetHashCode().ShouldNotBe(result2.GetHashCode());
+    }
+
     [Theory]
     [InlineData(true, "IsSuccess = True, Value = True", "")]
     [InlineData(false, "IsSuccess = False", "")]

--- a/tests/LightResults.Tests/ResultTests.cs
+++ b/tests/LightResults.Tests/ResultTests.cs
@@ -899,6 +899,50 @@ public sealed class ResultTests
     }
 
     [Fact]
+    public void Equals_Result_DefaultResults_ShouldReturnTrue()
+    {
+        // Arrange
+        Result result1 = default;
+        Result result2 = default;
+
+        // Assert
+        result1.Equals(result2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetHashCode_Result_DefaultResults_ShouldReturnSameHashCode()
+    {
+        // Arrange
+        Result result1 = default;
+        Result result2 = default;
+
+        // Assert
+        result1.GetHashCode().ShouldBe(result2.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_Result_DefaultAndFailure_ShouldReturnFalse()
+    {
+        // Arrange
+        Result result1 = default;
+        var result2 = Result.Failure();
+
+        // Assert
+        result1.Equals(result2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetHashCode_Result_DefaultAndFailure_ShouldReturnDifferentHashCodes()
+    {
+        // Arrange
+        Result result1 = default;
+        var result2 = Result.Failure();
+
+        // Assert
+        result1.GetHashCode().ShouldNotBe(result2.GetHashCode());
+    }
+
+    [Fact]
     public void ToString_WhenSuccess_ShouldReturnStringRepresentation()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- add regression tests for default result equality and hash code
- cover failure comparison cases
- implement a custom IActionableResult type for additional edge tests

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net9.0`

------
https://chatgpt.com/codex/tasks/task_e_686d804a041083288a2ffd59e9abc005