### PR TITLE
Optimize enumerable error conversion

### DIFF
--- a/src/LightResults/Result.cs
+++ b/src/LightResults/Result.cs
@@ -43,6 +43,20 @@ public readonly struct Result : IEquatable<Result>,
 
     private Result(IEnumerable<IError> errors)
     {
+        if (errors is IReadOnlyList<IError> list)
+        {
+            _errors = list;
+            return;
+        }
+
+        if (errors is ICollection<IError> collection)
+        {
+            var array = new IError[collection.Count];
+            collection.CopyTo(array, 0);
+            _errors = array;
+            return;
+        }
+
         _errors = errors.ToArray();
     }
 

--- a/src/LightResults/Result`1.cs
+++ b/src/LightResults/Result`1.cs
@@ -46,6 +46,20 @@ public readonly struct Result<TValue> : IEquatable<Result<TValue>>,
 
     internal Result(IEnumerable<IError> errors)
     {
+        if (errors is IReadOnlyList<IError> list)
+        {
+            _errors = list;
+            return;
+        }
+
+        if (errors is ICollection<IError> collection)
+        {
+            var array = new IError[collection.Count];
+            collection.CopyTo(array, 0);
+            _errors = array;
+            return;
+        }
+
         _errors = errors.ToArray();
     }
 

--- a/tests/LightResults.Tests/ResultTValueTests.cs
+++ b/tests/LightResults.Tests/ResultTValueTests.cs
@@ -437,6 +437,23 @@ public sealed class ResultTValueTests
     }
 
     [Fact]
+    public void Failure_WithErrorsEnumerable_ShouldReuseListInstance()
+    {
+        // Arrange
+        var errors = new List<IError>
+        {
+            new Error("Error 1"),
+            new Error("Error 2"),
+        };
+
+        // Act
+        var result = Result.Failure<int>(errors.AsEnumerable());
+
+        // Assert
+        result.Errors.ShouldBeSameAs(errors);
+    }
+
+    [Fact]
     public void Failure_WithErrorsReadOnlyList_ShouldCreateFailureResultWithMultipleErrors()
     {
         // Arrange
@@ -1300,7 +1317,7 @@ public sealed class ResultTValueTests
     public void InterfaceFailure_WithErrorsEnumerable_ShouldCreateFailureResultWithMultipleErrors()
     {
         // Arrange
-        static Result<TValue> Fail<TValue, TResult>()
+        static (Result<TValue> Result, List<IError> Errors) Fail<TValue, TResult>()
             where TResult : IActionableResult<TValue, Result<TValue>>
         {
             var errors = new List<IError>
@@ -1308,11 +1325,11 @@ public sealed class ResultTValueTests
                 new Error("Error 1"),
                 new Error("Error 2"),
             };
-            return TResult.Failure(errors.AsEnumerable());
+            return (TResult.Failure(errors.AsEnumerable()), errors);
         }
 
         // Act
-        var result = Fail<int, Result<int>>();
+        var (result, errors) = Fail<int, Result<int>>();
 
         // Assert
         result.IsSuccess().ShouldBeFalse();
@@ -1320,11 +1337,7 @@ public sealed class ResultTValueTests
         result.IsFailure().ShouldBeTrue();
         result.IsFailure(out _).ShouldBeTrue();
         result.Errors.Count.ShouldBe(2);
-        result.Errors.ShouldBeEquivalentTo(new List<IError>
-        {
-            new Error("Error 1"),
-            new Error("Error 2"),
-        }.ToArray());
+        result.Errors.ShouldBeSameAs(errors);
     }
 
     [Fact]

--- a/tests/LightResults.Tests/ResultTests.cs
+++ b/tests/LightResults.Tests/ResultTests.cs
@@ -368,6 +368,23 @@ public sealed class ResultTests
     }
 
     [Fact]
+    public void Failure_WithErrorsEnumerable_ShouldReuseListInstance()
+    {
+        // Arrange
+        var errors = new List<IError>
+        {
+            new Error("Error 1"),
+            new Error("Error 2"),
+        };
+
+        // Act
+        var result = Result.Failure(errors.AsEnumerable());
+
+        // Assert
+        result.Errors.ShouldBeSameAs(errors);
+    }
+
+    [Fact]
     public void Failure_WithErrorsReadOnlyList_ShouldCreateFailureResultWithMultipleErrors()
     {
         // Arrange
@@ -1077,7 +1094,7 @@ public sealed class ResultTests
     public void InterfaceFailure_WithErrorsEnumerable_ShouldCreateFailureResultWithMultipleErrors()
     {
         // Arrange
-        static Result Fail<TResult>()
+        static (Result Result, List<IError> Errors) Fail<TResult>()
             where TResult : IActionableResult<Result>
         {
             var errors = new List<IError>
@@ -1085,11 +1102,11 @@ public sealed class ResultTests
                 new Error("Error 1"),
                 new Error("Error 2"),
             };
-            return TResult.Failure(errors.AsEnumerable());
+            return (TResult.Failure(errors.AsEnumerable()), errors);
         }
 
         // Act
-        var result = Fail<Result>();
+        var (result, errors) = Fail<Result>();
 
         // Assert
         result.IsSuccess().ShouldBeFalse();
@@ -1097,11 +1114,7 @@ public sealed class ResultTests
         result.IsFailure(out _).ShouldBeTrue();
 
         result.Errors.Count.ShouldBe(2);
-        result.Errors.ShouldBeEquivalentTo(new List<IError>
-        {
-            new Error("Error 1"),
-            new Error("Error 2"),
-        }.ToArray());
+        result.Errors.ShouldBeSameAs(errors);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- avoid extra allocation when `Result`/`Result<T>` receive `IEnumerable<IError>`
- verify list instance is reused in enumerable overload
- update interface tests to expect list reuse

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net9.0`

------
https://chatgpt.com/codex/tasks/task_e_686d80e2fda08328a5211858055522a7