### PR TITLE
Fix whitespace issues

### DIFF
--- a/src/LightResults/Common/StringHelper.cs
+++ b/src/LightResults/Common/StringHelper.cs
@@ -15,7 +15,7 @@ internal static class StringHelper
     private const string PostResultStr = " }";
     private const string PreMessageStr = " { Message = \"";
     private const string PostMessageStr = "\" }";
-    
+
     public static string GetResultValueString<T>(T value)
     {
         switch (value)

--- a/tests/LightResults.Tests/CustomErrorTests.cs
+++ b/tests/LightResults.Tests/CustomErrorTests.cs
@@ -58,7 +58,7 @@ public sealed class CustomErrorTests
         var error = new CustomError(errorMessage);
 
         // Assert
-        error.ToString().ShouldBe(errorMessage.Length > 0 
+        error.ToString().ShouldBe(errorMessage.Length > 0
             ? $"CustomError {{ Message = \"{errorMessage}\" }}"
             : "CustomError");
     }


### PR DESCRIPTION
## Summary
- remove trailing whitespace in `CustomErrorTests`
- clean up blank line formatting in `StringHelper`

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net9.0 -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686d8c9bf8a08328b9832b4375f1a247