### PR TITLE
Apply AggressiveInlining attributes

### DIFF
--- a/src/LightResults/Common/SingleItemMetadataDictionary.cs
+++ b/src/LightResults/Common/SingleItemMetadataDictionary.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Runtime.CompilerServices;
 
 namespace LightResults.Common;
 
@@ -22,11 +23,13 @@ internal sealed class SingleItemMetadataDictionary : IReadOnlyDictionary<string,
 
     IEnumerable<object?> IReadOnlyDictionary<string, object?>.Values => new ValueEnumerable(_value);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool ContainsKey(string key)
     {
         return string.Equals(key, _key, StringComparison.Ordinal);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryGetValue(string key, out object? value)
     {
         if (ContainsKey(key))
@@ -39,16 +42,19 @@ internal sealed class SingleItemMetadataDictionary : IReadOnlyDictionary<string,
         return false;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private Enumerator GetEnumerator()
     {
         return new Enumerator(_key, _value);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     IEnumerator IEnumerable.GetEnumerator()
     {
         return GetEnumerator();
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     IEnumerator<KeyValuePair<string, object?>> IEnumerable<KeyValuePair<string, object?>>.GetEnumerator()
     {
         return GetEnumerator();
@@ -62,6 +68,7 @@ internal sealed class SingleItemMetadataDictionary : IReadOnlyDictionary<string,
 
         object IEnumerator.Current => Current;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool MoveNext()
         {
             if (_moved)
@@ -71,11 +78,13 @@ internal sealed class SingleItemMetadataDictionary : IReadOnlyDictionary<string,
             return true;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Reset()
         {
             _moved = false;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Dispose()
         {
         }
@@ -85,11 +94,13 @@ internal sealed class SingleItemMetadataDictionary : IReadOnlyDictionary<string,
     {
         private bool _moved;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         IEnumerator<string> IEnumerable<string>.GetEnumerator()
         {
             return this;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         IEnumerator IEnumerable.GetEnumerator()
         {
             return this;
@@ -99,6 +110,7 @@ internal sealed class SingleItemMetadataDictionary : IReadOnlyDictionary<string,
 
         object IEnumerator.Current => key;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool MoveNext()
         {
             if (_moved)
@@ -108,11 +120,13 @@ internal sealed class SingleItemMetadataDictionary : IReadOnlyDictionary<string,
             return true;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Reset()
         {
             _moved = false;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Dispose()
         {
         }
@@ -122,11 +136,13 @@ internal sealed class SingleItemMetadataDictionary : IReadOnlyDictionary<string,
     {
         private bool _moved;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         IEnumerator<object?> IEnumerable<object?>.GetEnumerator()
         {
             return this;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         IEnumerator IEnumerable.GetEnumerator()
         {
             return this;
@@ -136,6 +152,7 @@ internal sealed class SingleItemMetadataDictionary : IReadOnlyDictionary<string,
 
         object IEnumerator.Current => value!;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool MoveNext()
         {
             if (_moved)
@@ -145,11 +162,13 @@ internal sealed class SingleItemMetadataDictionary : IReadOnlyDictionary<string,
             return true;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Reset()
         {
             _moved = false;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Dispose()
         {
         }

--- a/src/LightResults/Common/StringHelper.cs
+++ b/src/LightResults/Common/StringHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Runtime.CompilerServices;
 
 namespace LightResults.Common;
 
@@ -16,6 +17,7 @@ internal static class StringHelper
     private const string PreMessageStr = " { Message = \"";
     private const string PostMessageStr = "\" }";
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string GetResultValueString<T>(T value)
     {
         switch (value)
@@ -71,11 +73,13 @@ internal static class StringHelper
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string GetResultValueString(IFormattable value)
     {
         return GetResultValueValueString(value.ToString(null, CultureInfo.InvariantCulture));
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static string GetResultCharValueString(string valueString)
     {
 #if NET6_0_OR_GREATER
@@ -92,6 +96,7 @@ internal static class StringHelper
 #endif
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static string GetResultStringValueString(string valueString)
     {
 #if NET6_0_OR_GREATER
@@ -108,6 +113,7 @@ internal static class StringHelper
 #endif
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static string GetResultValueValueString(string valueString)
     {
 #if NET6_0_OR_GREATER
@@ -118,6 +124,7 @@ internal static class StringHelper
 #endif
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string GetResultErrorString(string errorMessage)
     {
 #if NET6_0_OR_GREATER
@@ -128,6 +135,7 @@ internal static class StringHelper
 #endif
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string GetErrorString(string type, string message)
     {
 #if NET6_0_OR_GREATER
@@ -151,6 +159,7 @@ internal static class StringHelper
     private const int PreMessageStrLength = 14;
     private const int PostMessageStrLength = 3;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void GetResultValueSpan(Span<char> span, string state)
     {
         PreResultStr.AsSpan()
@@ -169,6 +178,7 @@ internal static class StringHelper
             .CopyTo(span);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void GetResultValueCharSpan(Span<char> span, string state)
     {
         PreResultStr.AsSpan()
@@ -193,6 +203,7 @@ internal static class StringHelper
             .CopyTo(span);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void GetResultValueStringSpan(Span<char> span, string state)
     {
         PreResultStr.AsSpan()
@@ -217,6 +228,7 @@ internal static class StringHelper
             .CopyTo(span);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void GetResultErrorSpan(Span<char> span, string state)
     {
         PreResultStr.AsSpan()
@@ -238,6 +250,7 @@ internal static class StringHelper
             .CopyTo(span);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void GetErrorSpan(Span<char> span, (string errorType, string errorMessage) state)
     {
         state.errorType

--- a/src/LightResults/Error.cs
+++ b/src/LightResults/Error.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using LightResults.Common;
 
 namespace LightResults;
@@ -16,6 +17,7 @@ public class Error : IError, IEquatable<Error>
     /// <returns>An <see cref="Exception"/> instance when the metadata contains an entry named <c>"Exception"</c> with a value of type <see cref="Exception"/>; otherwise, <see langword="null"/>.</returns>
     public Exception? Exception
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
             if (Metadata.TryGetValue(ExceptionKey, out var value) && value is Exception ex)
@@ -118,6 +120,7 @@ public class Error : IError, IEquatable<Error>
     /// <summary>Determines whether the specified <see cref="Error"/> is equal to this instance.</summary>
     /// <param name="other">The <see cref="Error"/> to compare with this instance.</param>
     /// <returns><c>true</c> if the specified <see cref="Error"/> is equal to this instance; otherwise, <c>false</c>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Equals(Error? other)
     {
         if (ReferenceEquals(null, other))
@@ -145,12 +148,14 @@ public class Error : IError, IEquatable<Error>
     }
 
     /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override bool Equals(object? obj)
     {
         return obj is Error other && Equals(other);
     }
 
     /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override int GetHashCode()
     {
         var hash = new HashCode();
@@ -168,6 +173,7 @@ public class Error : IError, IEquatable<Error>
     /// <param name="left">The first <see cref="Error"/> instance to compare.</param>
     /// <param name="right">The second <see cref="Error"/> instance to compare.</param>
     /// <returns><c>true</c> if the specified <see cref="Error"/> instances are equal; otherwise, <c>false</c>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(Error? left, Error? right)
     {
         if (left is null)
@@ -180,12 +186,14 @@ public class Error : IError, IEquatable<Error>
     /// <param name="left">The first <see cref="Error"/> instance to compare.</param>
     /// <param name="right">The second <see cref="Error"/> instance to compare.</param>
     /// <returns><c>true</c> if the specified <see cref="Error"/> instances are not equal; otherwise, <c>false</c>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator !=(Error? left, Error? right)
     {
         return !(left == right);
     }
 
     /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override string ToString()
     {
         var type = GetType();

--- a/src/LightResults/Result.cs
+++ b/src/LightResults/Result.cs
@@ -68,6 +68,7 @@ public readonly struct Result : IEquatable<Result>,
 
     /// <summary>Creates a success result.</summary>
     /// <returns>A new instance of <see cref="Result"/> representing a success result with the specified value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result Success()
     {
         return SuccessResult;
@@ -77,6 +78,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="value">The value to include in the result.</param>
     /// <typeparam name="TValue">The type of the value of the result.</typeparam>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a success result with the specified value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<TValue> Success<TValue>(TValue value)
     {
         return new Result<TValue>(value);
@@ -91,6 +93,7 @@ public readonly struct Result : IEquatable<Result>,
 
     /// <summary>Creates a failure result.</summary>
     /// <returns>A new instance of <see cref="Result"/> representing a failure result.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result Failure()
     {
         return FailureResult;
@@ -99,6 +102,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <summary>Creates a failure result with the given error message.</summary>
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified error message.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result Failure(string errorMessage)
     {
         var error = new Error(errorMessage);
@@ -109,6 +113,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified error message and metadata.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result Failure(string errorMessage, (string Key, object? Value) metadata)
     {
         var dictionary = new SingleItemMetadataDictionary(metadata.Key, metadata.Value);
@@ -120,6 +125,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified error message and metadata.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result Failure(string errorMessage, KeyValuePair<string, object?> metadata)
     {
         var dictionary = new SingleItemMetadataDictionary(metadata.Key, metadata.Value);
@@ -131,6 +137,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified error message and metadata.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result Failure(string errorMessage, IReadOnlyDictionary<string, object?> metadata)
     {
         var error = new Error(errorMessage, metadata);
@@ -141,6 +148,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="ex">The <see cref="Exception"/> associated with the failure, if any.</param>
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified exception.</returns>
     /// <remarks>The exception is added to the error <see cref="Error.Metadata"/> under the key of "Exception" and the error <see cref="Error.Message"/> is set to that of the exception.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result Failure(Exception? ex)
     {
         var error = new Error(ex);
@@ -152,6 +160,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="ex">The <see cref="Exception"/> associated with the failure, if any.</param>
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified error message and exception.</returns>
     /// <remarks>The exception is added to the error <see cref="Error.Metadata"/> under the key of "Exception".</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result Failure(string errorMessage, Exception? ex)
     {
         var error = new Error(errorMessage, ex);
@@ -161,6 +170,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <summary>Creates a failure result with the given error.</summary>
     /// <param name="error">The error associated with the failure.</param>
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified error.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result Failure(IError error)
     {
         return new Result(error);
@@ -169,6 +179,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <summary>Creates a failure result with the given errors.</summary>
     /// <param name="errors">A collection of errors associated with the failure.</param>
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified errors.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result Failure(IEnumerable<IError> errors)
     {
         return new Result(errors);
@@ -177,6 +188,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <summary>Creates a failure result with the given errors.</summary>
     /// <param name="errors">A collection of errors associated with the failure.</param>
     /// <returns>A new instance of <see cref="Result"/> representing a failure result with the specified errors.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result Failure(IReadOnlyList<IError> errors)
     {
         return new Result(errors);
@@ -185,6 +197,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <summary>Creates a failure result.</summary>
     /// <typeparam name="TValue">The type of the value of the result.</typeparam>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<TValue> Failure<TValue>()
     {
         return Result<TValue>.FailureResult;
@@ -194,6 +207,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="errorMessage">The error message associated with the failure.</param>
     /// <typeparam name="TValue">The type of the value of the result.</typeparam>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<TValue> Failure<TValue>(string errorMessage)
     {
         var error = new Error(errorMessage);
@@ -205,6 +219,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <typeparam name="TValue">The type of the value of the result.</typeparam>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message and metadata.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<TValue> Failure<TValue>(string errorMessage, (string Key, object? Value) metadata)
     {
         var dictionary = new SingleItemMetadataDictionary(metadata.Key, metadata.Value);
@@ -217,6 +232,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <typeparam name="TValue">The type of the value of the result.</typeparam>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message and metadata.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<TValue> Failure<TValue>(string errorMessage, KeyValuePair<string, object?> metadata)
     {
         var dictionary = new SingleItemMetadataDictionary(metadata.Key, metadata.Value);
@@ -229,6 +245,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="metadata">The metadata associated with the failure.</param>
     /// <typeparam name="TValue">The type of the value of the result.</typeparam>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message and metadata.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<TValue> Failure<TValue>(string errorMessage, IReadOnlyDictionary<string, object?> metadata)
     {
         var error = new Error(errorMessage, metadata);
@@ -239,6 +256,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="ex">The <see cref="Exception"/> associated with the failure, if any.</param>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified exception.</returns>
     /// <remarks>The exception is added to the error <see cref="Error.Metadata"/> under the key of "Exception" and the error <see cref="Error.Message"/> is set to that of the exception.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<TValue> Failure<TValue>(Exception? ex)
     {
         var error = new Error(ex);
@@ -250,6 +268,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="ex">The <see cref="Exception"/> associated with the failure, if any.</param>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error message and exception.</returns>
     /// <remarks>The exception is added to the error <see cref="Error.Metadata"/> under the key of "Exception".</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<TValue> Failure<TValue>(string errorMessage, Exception? ex)
     {
         var error = new Error(errorMessage, ex);
@@ -260,6 +279,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="error">The error associated with the failure.</param>
     /// <typeparam name="TValue">The type of the value of the result.</typeparam>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<TValue> Failure<TValue>(IError error)
     {
         return new Result<TValue>(error);
@@ -269,6 +289,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="errors">A collection of errors associated with the failure.</param>
     /// <typeparam name="TValue">The type of the value of the result.</typeparam>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified errors.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<TValue> Failure<TValue>(IEnumerable<IError> errors)
     {
         return new Result<TValue>(errors);
@@ -278,6 +299,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="errors">A collection of errors associated with the failure.</param>
     /// <typeparam name="TValue">The type of the value of the result.</typeparam>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified errors.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<TValue> Failure<TValue>(IReadOnlyList<IError> errors)
     {
         return new Result<TValue>(errors);
@@ -398,6 +420,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <summary>Determines whether two <see cref="Result"/> instances are equal.</summary>
     /// <param name="other">The <see cref="Result"/> instance to compare with this instance.</param>
     /// <returns><c>true</c> if the specified <see cref="Result"/> is equal to this instance; otherwise, <c>false</c>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Equals(in Result other)
     {
         return Equals(_errors, other._errors);
@@ -406,12 +429,14 @@ public readonly struct Result : IEquatable<Result>,
     /// <summary>Determines whether the specified object is equal to this instance.</summary>
     /// <param name="obj">The object to compare with this instance.</param>
     /// <returns><c>true</c> if the specified object is equal to this instance; otherwise, <c>false</c>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override bool Equals(object? obj)
     {
         return obj is Result other && Equals(in other);
     }
 
     /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     bool IEquatable<Result>.Equals(Result other)
     {
         return Equals(in other);
@@ -419,6 +444,7 @@ public readonly struct Result : IEquatable<Result>,
 
     /// <summary>Returns the hash code for this instance.</summary>
     /// <returns>A 32-bit signed integer hash code.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override int GetHashCode()
     {
         return HashCode.Combine(_errors);
@@ -428,6 +454,7 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="left">The first <see cref="Result"/> instance to compare.</param>
     /// <param name="right">The second <see cref="Result"/> instance to compare.</param>
     /// <returns><c>true</c> if the specified <see cref="Result"/> instances are equal; otherwise, <c>false</c>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(in Result left, in Result right)
     {
         return left.Equals(in right);
@@ -437,12 +464,14 @@ public readonly struct Result : IEquatable<Result>,
     /// <param name="left">The first <see cref="Result"/> instance to compare.</param>
     /// <param name="right">The second <see cref="Result"/> instance to compare.</param>
     /// <returns><c>true</c> if the specified <see cref="Result"/> instances are not equal; otherwise, <c>false</c>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator !=(in Result left, in Result right)
     {
         return !left.Equals(in right);
     }
 
     /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override string ToString()
     {
         if (_isSuccess)

--- a/src/LightResults/Result`1.cs
+++ b/src/LightResults/Result`1.cs
@@ -299,6 +299,7 @@ public readonly struct Result<TValue> : IEquatable<Result<TValue>>,
     /// <param name="value">The value to convert into a success result.</param>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a success result with the specified value.</returns>
     [SuppressMessage("Usage", "CA2225: Operator overloads have named alternates", Justification = "We don't want to expose named alternates in this case.")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Result<TValue>(TValue value)
     {
         return new Result<TValue>(value);
@@ -308,6 +309,7 @@ public readonly struct Result<TValue> : IEquatable<Result<TValue>>,
     /// <param name="error">The error to convert into a failure result.</param>
     /// <returns>A new instance of <see cref="Result{TValue}"/> representing a failure result with the specified error.</returns>
     [SuppressMessage("Usage", "CA2225: Operator overloads have named alternates", Justification = "We don't want to expose named alternates in this case.")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Result<TValue>(Error error)
     {
         return new Result<TValue>(error);
@@ -339,6 +341,7 @@ public readonly struct Result<TValue> : IEquatable<Result<TValue>>,
     /// <summary>Determines whether two <see cref="Result{TValue}"/> instances are equal.</summary>
     /// <param name="other">The <see cref="Result{TValue}"/> instance to compare with this instance.</param>
     /// <returns><c>true</c> if the specified <see cref="Result{TValue}"/> is equal to this instance; otherwise, <c>false</c>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Equals(in Result<TValue> other)
     {
         return Equals(_errors, other._errors) && EqualityComparer<TValue?>.Default.Equals(_valueOrDefault, other._valueOrDefault);
@@ -347,12 +350,14 @@ public readonly struct Result<TValue> : IEquatable<Result<TValue>>,
     /// <summary>Determines whether the specified object is equal to this instance.</summary>
     /// <param name="obj">The object to compare with this instance.</param>
     /// <returns><c>true</c> if the specified object is equal to this instance; otherwise, <c>false</c>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override bool Equals(object? obj)
     {
         return obj is Result<TValue> other && Equals(in other);
     }
 
     /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     bool IEquatable<Result<TValue>>.Equals(Result<TValue> other)
     {
         return Equals(in other);
@@ -360,6 +365,7 @@ public readonly struct Result<TValue> : IEquatable<Result<TValue>>,
 
     /// <summary>Returns the hash code for this instance.</summary>
     /// <returns>A 32-bit signed integer hash code.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override int GetHashCode()
     {
         return HashCode.Combine(_errors, _valueOrDefault);
@@ -369,6 +375,7 @@ public readonly struct Result<TValue> : IEquatable<Result<TValue>>,
     /// <param name="left">The first <see cref="Result{TValue}"/> instance to compare.</param>
     /// <param name="right">The second <see cref="Result{TValue}"/> instance to compare.</param>
     /// <returns><c>true</c> if the specified <see cref="Result{TValue}"/> instances are equal; otherwise, <c>false</c>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(in Result<TValue> left, in Result<TValue> right)
     {
         return left.Equals(in right);
@@ -378,12 +385,14 @@ public readonly struct Result<TValue> : IEquatable<Result<TValue>>,
     /// <param name="left">The first <see cref="Result{TValue}"/> instance to compare.</param>
     /// <param name="right">The second <see cref="Result{TValue}"/> instance to compare.</param>
     /// <returns><c>true</c> if the specified <see cref="Result{TValue}"/> instances are not equal; otherwise, <c>false</c>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator !=(in Result<TValue> left, in Result<TValue> right)
     {
         return !left.Equals(in right);
     }
 
     /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override string ToString()
     {
         if (_isSuccess)


### PR DESCRIPTION
## Summary
- hint JIT to inline frequently used methods
- decorate helper enumerators and string helpers for inlining
- inline comparison and formatting helpers

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net9.0`

------
https://chatgpt.com/codex/tasks/task_e_686d937a33f483288eed10d6938a5951