### PR TITLE
Update docs for patch features

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ if (result.IsSuccess(out var value))
 }
 ```
 
+### Converting failed results
+
+A failed result can be converted to another result type using `AsFailure`.
+
+```csharp
+var result = Result.Failure("Invalid input");
+var typed = result.AsFailure<int>();
+var backToNonGeneric = typed.AsFailure();
+```
+
+
 ### Creating errors
 
 Errors can be created with or without a message.
@@ -124,6 +135,10 @@ var errorWithMetadataTuple = new Error("Something went wrong!", ("Key", "Value")
 
 var metadata = new Dictionary<string, object> { { "Key", "Value" } };
 var errorWithMetadataDictionary = new Error("Something went wrong!", metadata);
+
+var errorWithMetadataKeyValuePair = new Error("Something went wrong!", new KeyValuePair<string, object>("Key", "Value"));
+
+var errorWithMetadataEnumerable = new Error("Something went wrong!", new[] { new KeyValuePair<string, object>("Key", "Value") });
 
 var ex = new InvalidOperationException();
 var errorWithException = new Error(ex);
@@ -333,3 +348,8 @@ The following steps in the following order will reduce the amount of manual work
     - `Error(string message, Exception exception)` has been added.
     - `Error.Empty` is now publicly accessible.
     - `Exception { get; }` has been added.
+- New helper methods were added to convert failed results.
+    - `result.AsFailure()` and `result.AsFailure<T>()` convert an existing result into a failure result of another type.
+- Additional `Error` constructors were introduced for metadata collections.
+    - `Error(string message, KeyValuePair<string, object?> metadata)` has been added.
+    - `Error(string message, IEnumerable<KeyValuePair<string, object?>> metadata)` has been added.

--- a/docfx/docs/breaking-changes.md
+++ b/docfx/docs/breaking-changes.md
@@ -54,3 +54,8 @@ The following steps in the following order will reduce the amount of manual work
 - New property initializers where added to `Error`.
     - `Message { get; }` has changed to `Message { get; init; }`.
     - `Metadata { get; }` has changed to `Metadata { get; init; }`.
+- New helper methods were added to convert failed results.
+    - `result.AsFailure()` and `result.AsFailure<T>()` convert an existing result into a failure result of another type.
+- Additional `Error` constructors were introduced for metadata collections.
+    - `Error(string message, KeyValuePair<string, object?> metadata)` has been added.
+    - `Error(string message, IEnumerable<KeyValuePair<string, object?>> metadata)` has been added.

--- a/docfx/docs/getting-started.md
+++ b/docfx/docs/getting-started.md
@@ -62,6 +62,17 @@ if (result.IsSuccess(out var value))
 }
 ```
 
+### Converting failed results
+
+A failed result can be converted to another result type using `AsFailure`.
+
+```csharp
+var result = Result.Failure("Invalid input");
+var typed = result.AsFailure<int>();
+var backToNonGeneric = typed.AsFailure();
+```
+
+
 ### Creating errors
 
 Errors can be created with or without a message.
@@ -79,6 +90,10 @@ var errorWithMetadataTuple = new Error("Something went wrong!", ("Key", "Value")
 
 var metadata = new Dictionary<string, object> { { "Key", "Value" } };
 var errorWithMetadataDictionary = new Error("Something went wrong!", metadata);
+
+var errorWithMetadataKeyValuePair = new Error("Something went wrong!", new KeyValuePair<string, object>("Key", "Value"));
+
+var errorWithMetadataEnumerable = new Error("Something went wrong!", new[] { new KeyValuePair<string, object>("Key", "Value") });
 ```
 
 ### Custom errors


### PR DESCRIPTION
## Summary
- document new `AsFailure` helpers in README and docs
- mention key-value pair and enumerable Error constructors
- show new error examples and AsFailure conversions in documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d99efba688328a4cad6dd00a84174