### PR TITLE
Preallocate failure errors for IReadOnlyCollection inputs

### DIFF
--- a/src/LightResults/Result.cs
+++ b/src/LightResults/Result.cs
@@ -54,6 +54,20 @@ public readonly struct Result : IEquatable<Result>,
             return;
         }
 
+        if (errors is IReadOnlyCollection<IError> readOnlyCollection)
+        {
+            var array = new IError[readOnlyCollection.Count];
+            var index = 0;
+
+            foreach (var error in readOnlyCollection)
+            {
+                array[index++] = error;
+            }
+
+            _errors = array;
+            return;
+        }
+
         _errors = errors.ToArray();
     }
 

--- a/src/LightResults/Result`1.cs
+++ b/src/LightResults/Result`1.cs
@@ -57,6 +57,20 @@ public readonly struct Result<TValue> : IEquatable<Result<TValue>>,
             return;
         }
 
+        if (errors is IReadOnlyCollection<IError> readOnlyCollection)
+        {
+            var array = new IError[readOnlyCollection.Count];
+            var index = 0;
+
+            foreach (var error in readOnlyCollection)
+            {
+                array[index++] = error;
+            }
+
+            _errors = array;
+            return;
+        }
+
         _errors = errors.ToArray();
     }
 

--- a/tests/LightResults.Tests/ResultTests.cs
+++ b/tests/LightResults.Tests/ResultTests.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using Shouldly;
 using LightResults.Common;
 
@@ -187,6 +188,38 @@ public sealed class ResultTests
 
         var singleError = result.Errors.ShouldHaveSingleItem();
         singleError.Message.ShouldBe(errorMessage);
+    }
+
+    [Fact]
+    public void Failure_WithReadOnlyCollection_ShouldPreallocateFromCount()
+    {
+        // Arrange
+        var firstError = new Error("first");
+        var secondError = new Error("second");
+        var errors = new TestReadOnlyCollection(firstError, secondError);
+
+        // Act
+        var result = Result.Failure(errors);
+
+        // Assert
+        errors.CountAccesses.ShouldBe(1);
+        result.Errors.ShouldBe(new IError[] { firstError, secondError });
+    }
+
+    [Fact]
+    public void FailureTValue_WithReadOnlyCollection_ShouldPreallocateFromCount()
+    {
+        // Arrange
+        var firstError = new Error("first");
+        var secondError = new Error("second");
+        var errors = new TestReadOnlyCollection(firstError, secondError);
+
+        // Act
+        var result = Result.Failure<int>(errors);
+
+        // Assert
+        errors.CountAccesses.ShouldBe(1);
+        result.Errors.ShouldBe(new IError[] { firstError, secondError });
     }
 
     [Fact]
@@ -1331,5 +1364,39 @@ public sealed class ResultTests
                 new Error("Error 2"),
             }
         );
+    }
+
+    private sealed class TestReadOnlyCollection : IReadOnlyCollection<IError>
+    {
+        private readonly IError[] _errors;
+
+        internal TestReadOnlyCollection(params IError[] errors)
+        {
+            _errors = errors;
+        }
+
+        internal int CountAccesses { get; private set; }
+
+        public int Count
+        {
+            get
+            {
+                CountAccesses++;
+                return _errors.Length;
+            }
+        }
+
+        public IEnumerator<IError> GetEnumerator()
+        {
+            for (var index = 0; index < _errors.Length; index++)
+            {
+                yield return _errors[index];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add an IReadOnlyCollection<IError> fast path in the failure constructors for Result and Result<T> to avoid an extra array allocation
- add unit tests that exercise the new path to ensure the Count property is used when only IReadOnlyCollection is implemented

## Testing
- dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net10.0

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a138d7b388328a0509f98d85ad0c0)