### PR TITLE
Sync docfx docs with updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,15 @@ excellent work with [FluentResults](https://github.com/altmann/FluentResults).
 
 ## References
 
-This library targets .NET Standard 2.0, .NET 6.0, .NET 7.0, .NET 8.0, and .NET 9.0.
+This library currently targets .NET 8.0, .NET 9.0, and .NET 10.0 with no external runtime dependencies.
+
+## Installation
+
+Install the library from NuGet:
+
+```bash
+dotnet add package LightResults
+```
 
 ## Dependencies
 
@@ -28,8 +36,7 @@ This library has no dependencies.
 - 🧵 Thread-safe — Error and metadata collections are read-only.
 - ✨ Modern — Built against the latest version of .NET using the most recent best practices.
 - 🧪 Native — Written, compiled, and tested against the latest versions of .NET.
-- ❤️ Compatible — Available for dozens of versions of .NET as a
-  [.NET Standard 2.0](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0) library.
+- ❤️ Compatible — Multi-targeted for current LTS and STS releases.
 - 🪚 Trimmable — Compatible with [ahead-of-time compilation](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/) (AOT) as of .NET 7.0.
 - 🚀 Performant — Heavily optimized and [benchmarked](https://jscarle.github.io/LightResults/docs/performance.html) to aim for the highest possible performance.
 
@@ -43,11 +50,11 @@ Make sure to [read the docs](https://jscarle.github.io/LightResults/) for the fu
 
 ## Getting Started
 
-LightResults consists of only three types: `Result`, `Result<TValue>`, and `Error`.
+LightResults centers on three primary types—`Result`, `Result<TValue>`, and `Error`—plus the `IResult`/`IResult<TValue>` and `IError` interfaces for extensibility.
 
-- The `Result` class represents a generic result indicating success or failure.
-- The `Result<TValue>` class represents a success or failure result with a value.
-- The `Error` class represents an error with a message and optional associated metadata.
+- The `Result` struct represents a generic result indicating success or failure.
+- The `Result<TValue>` struct represents a success or failure result with a value.
+- The `Error` struct represents an error with a message, optional metadata, and an optional exception.
 
 ### Creating a successful result
 
@@ -310,6 +317,8 @@ public static class AppError
 ```
 
 ## What's new in v9.0
+
+LightResults 10.0 builds on the redesigned API introduced in v9.0. If you're upgrading from v8.0, the following notes still apply and outline the breaking changes between those versions.
 
 The API for LightResults was completely redesigned for v9.0 to improve performance and remove any potential pits of failure caused by the prior version's use
 of properties that could result in exceptions being thrown when values were accessed without checking the state of the result. Thus, there are several breaking

--- a/docfx/docs/breaking-changes.md
+++ b/docfx/docs/breaking-changes.md
@@ -1,5 +1,8 @@
 # What's new in v9.0
 
+LightResults 10.0 builds on the redesigned API introduced in v9.0. If you're upgrading from v8.0, the following notes still apply and outline the breaking
+changes between those versions.
+
 The API for LightResults was completely redesigned for v9.0 to improve performance and remove any potential pits of failure caused by the prior version's use
 of properties that could result in exceptions being thrown when values were accessed without checking the state of the result. Thus, there are several breaking
 changes, detailed below, that developers must be aware of when upgrading from v8.0 to v9.0.

--- a/docfx/docs/getting-started.md
+++ b/docfx/docs/getting-started.md
@@ -1,10 +1,11 @@
 # Getting Started
 
-LightResults consists of only three classes `Result`, `Result<TValue>`, and `Error`.
+LightResults centers on two result structs—`Result` and `Result<TValue>`—plus the `Error` struct and `IResult`/`IResult<TValue>`
+and `IError` interfaces for extensibility.
 
-- The `Result` class represents a generic result indicating success or failure.
-- The `Result<TValue>` class represents a success or failure result with a value.
-- The `Error` class represents an error with a message and optional associated metadata.
+- The `Result` struct represents a generic result indicating success or failure.
+- The `Result<TValue>` struct represents a success or failure result with a value.
+- The `Error` struct represents an error with a message and optional associated metadata.
 
 ### Creating a successful result
 
@@ -32,7 +33,7 @@ var failureResultWithMessageAndException = Result.Failure("Operation failure!", 
 
 ### Checking the state of a result
 
-There are two methods used to check a result, `IsSuccess()` and `IsFailed()`. Both of which have several overloads to obtain the
+There are two methods used to check a result, `IsSuccess()` and `IsFailure()`. Both of which have several overloads to obtain the
 value and error.
 
 ```csharp
@@ -53,7 +54,7 @@ if (result.IsFailure(out var error))
 
 ### Getting the value
 
-The value from a successful result can be retrieved through the `out` parameter of the `Success()` method.
+The value from a successful result can be retrieved through the `out` parameter of the `IsSuccess()` method.
 
 ```csharp
 if (result.IsSuccess(out var value))
@@ -173,17 +174,17 @@ public sealed class HttpError : Error
 We can further simplify creating errors by creating an error factory.
 
 ```csharp
-public static AppError
+public static class AppError
 {
-    public Result NotFound()
+    public static Result NotFound()
     {
         var notFoundError = new NotFoundError();
         return Result.Failure(notFoundError);
     }
 
-    public Result HttpError(HttpStatusCode statusCode)
+    public static Result HttpError(HttpStatusCode statusCode)
     {
-        var httpError = new HttpError(statusCode)
+        var httpError = new HttpError(statusCode);
         return Result.Failure(httpError);
     }
 }
@@ -232,17 +233,18 @@ introduced in .NET 7.0 (C# 11.0), it is possible to use generics to obtain acces
 of the generic variant of the result. As such the error factory can be enhanced to take advantage of that.
 
 ```csharp
-public static AppError
+public static class AppError
 {
-    public Result NotFound()
+    public static Result NotFound()
     {
         var notFoundError = new NotFoundError();
         return Result.Failure(notFoundError);
     }
-    
-    public TResult NotFound<TResult>()
+
+    public static TResult NotFound<TResult>()
+        where TResult : IResult<TResult>
     {
-        var notFoundError = new NotFoundError(); 
+        var notFoundError = new NotFoundError();
         return TResult.Failure(notFoundError);
     }
 }

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -20,7 +20,15 @@ excellent work with [FluentResults](https://github.com/altmann/FluentResults).
 
 ## References
 
-This library targets .NET Standard 2.0, .NET 6.0, .NET 7.0, .NET 8.0, and .NET 9.0.
+This library targets .NET 8.0, .NET 9.0, and .NET 10.0 with no external runtime dependencies.
+
+## Installation
+
+Install the library from NuGet:
+
+```bash
+dotnet add package LightResults
+```
 
 ## Dependencies
 
@@ -34,7 +42,7 @@ This library has no dependencies.
 - 🧵 Thread-safe — Error and metadata collections are read-only.
 - ✨ Modern — Built against the latest version of .NET using the most recent best practices.
 - 🧪 Native — Written, compiled, and tested against the latest versions of .NET.
-- ❤️ Compatible — Available for dozens of versions of .NET as a [.NET Standard 2.0](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0) library.
+- ❤️ Compatible — Multi-targeted for current .NET LTS and STS releases.
 - 🪚 Trimmable — Compatible with [ahead-of-time compilation](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/) (AOT) as of .NET 7.0.
 - 🚀 Performant — Heavily optimized and [benchmarked](https://jscarle.github.io/LightResults/docs/performance.html) to aim for the highest possible performance.
 


### PR DESCRIPTION
## Summary
- update docfx landing page to list current .NET 8/9/10 targets, add installation snippet, and adjust compatibility note
- refresh getting started guide descriptions and code samples to match the primary LightResults types and correct IsFailure usage
- add v10 migration context to the breaking changes page for consistency with README

## Testing
- Not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921e28733748328bf0c38acc36aebce)