### PR TITLE
Optimize Error.Equals metadata short-circuit

### DIFF
--- a/src/LightResults/Error.cs
+++ b/src/LightResults/Error.cs
@@ -150,7 +150,14 @@ public class Error : IError, IEquatable<Error>
         if (!Message.Equals(other.Message, StringComparison.Ordinal))
             return false;
 
-        if (Metadata.Count != other.Metadata.Count)
+        if (ReferenceEquals(Metadata, other.Metadata))
+            return true;
+
+        var metadataCount = Metadata.Count;
+        if (metadataCount == 0 && other.Metadata.Count == 0)
+            return true;
+
+        if (metadataCount != other.Metadata.Count)
             return false;
 
         foreach (var kvp in Metadata)


### PR DESCRIPTION
## Summary
- add early returns in Error.Equals when metadata references match or are empty to avoid unnecessary iteration

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921f2967db48328ab24228c7f8a3d6b)