### PR TITLE
Optimize empty error metadata checks

### DIFF
--- a/src/LightResults/Error.cs
+++ b/src/LightResults/Error.cs
@@ -11,7 +11,7 @@ namespace LightResults;
 public class Error : IError, IEquatable<Error>
 {
     /// <summary>Gets an empty <see cref="Error"/> instance.</summary>
-    public static IError Empty { get; } = new Error("", new Dictionary<string, object?>());
+    public static IError Empty { get; } = new Error("", EmptyMetaData);
 
     /// <inheritdoc/>
     public string Message { get; init; }
@@ -22,6 +22,9 @@ public class Error : IError, IEquatable<Error>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
+            if (Metadata.Count == 0)
+                return null;
+
             if (Metadata.TryGetValue(ExceptionKey, out var value) && value is Exception ex)
                 return ex;
 


### PR DESCRIPTION
## Summary
- reuse the shared empty metadata dictionary for the static empty error instance
- short-circuit exception lookup when no metadata is present to avoid extra dictionary lookups

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921f8e40cf88328a85a1a5b16aeebcc)