### PR TITLE
Avoid bool ToString allocation in StringHelper

### DIFF
--- a/src/LightResults/Common/StringHelper.cs
+++ b/src/LightResults/Common/StringHelper.cs
@@ -23,7 +23,7 @@ internal static class StringHelper
         switch (value)
         {
             case bool booleanValue:
-                return GetResultValueValueString(booleanValue.ToString());
+                return GetResultValueValueString(booleanValue ? TrueString : FalseString);
             case sbyte sbyteValue:
                 return GetResultValueValueString(sbyteValue.ToString(CultureInfo.InvariantCulture));
             case byte byteValue:
@@ -133,6 +133,9 @@ internal static class StringHelper
     private const int PostResultStrLength = 2;
     private const int PreMessageStrLength = 14;
     private const int PostMessageStrLength = 3;
+
+    private const string TrueString = "True";
+    private const string FalseString = "False";
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void GetResultValueSpan(Span<char> span, string state)


### PR DESCRIPTION
## Summary
- reuse interned boolean strings when formatting result values to avoid allocations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921f8e40cf88328a85a1a5b16aeebcc)