### PR TITLE
Add fallback message test for exception-based errors

### DIFF
--- a/tests/LightResults.Tests/ErrorTests.cs
+++ b/tests/LightResults.Tests/ErrorTests.cs
@@ -160,6 +160,23 @@ public sealed class ErrorTests
     }
 
     [Fact]
+    public void ConstructorWithException_ShouldFallbackMessageWhenExceptionMessageIsEmpty()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("");
+
+        // Act
+        var error = new Error(exception);
+
+        // Assert
+        error.Message.ShouldBe($"An exception of type {exception.GetType().Name} was thrown.");
+        error.Metadata.Count.ShouldBe(1);
+        var metadata = error.Metadata.Single();
+        metadata.Key.ShouldBe("Exception");
+        metadata.Value.ShouldBe(exception);
+    }
+
+    [Fact]
     public void ConstructorWithMessageAndException_ShouldCreateErrorWithMessageAndMetadata()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- add coverage for creating errors from exceptions with empty messages
- verify the fallback message format and stored exception metadata

## Testing
- dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net10.0

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921fb797fcc83289342495713524b2c)