### PR TITLE
Add test for failure with empty errors enumerable

### DIFF
--- a/tests/LightResults.Tests/ResultTValueTests.cs
+++ b/tests/LightResults.Tests/ResultTValueTests.cs
@@ -452,6 +452,28 @@ public sealed class ResultTValueTests
     }
 
     [Fact]
+    public void Failure_WithEmptyErrorsEnumerable_ShouldCreateFailureWithoutErrors()
+    {
+        // Arrange
+        var result = Result<int>.Failure(Enumerable.Empty<IError>());
+
+        // Assert
+        result.IsSuccess().ShouldBeFalse();
+        result.IsFailure().ShouldBeTrue();
+        result.IsSuccess(out var resultValue).ShouldBeFalse();
+        resultValue.ShouldBe(default(int));
+        result.IsFailure(out var resultError).ShouldBeFalse();
+        resultError.ShouldBeNull();
+        result.Errors.ShouldBeEmpty();
+        result.HasError<Error>().ShouldBeFalse();
+        result.HasError<Error>(out var error).ShouldBeFalse();
+        error.ShouldBeNull();
+        result.HasError<ValidationError>().ShouldBeFalse();
+        result.HasError<ValidationError>(out var validationError).ShouldBeFalse();
+        validationError.ShouldBeNull();
+    }
+
+    [Fact]
     public void Failure_WithErrorsReadOnlyList_ShouldCreateFailureResultWithMultipleErrors()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- add a regression test for failures created with an empty error enumerable to verify status, values, and error queries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921fdfb52a48328b71aee5068ba3e0d)