### PR TITLE
Add IsSuccess default error coverage for Result

### DIFF
--- a/tests/LightResults.Tests/ResultTValueTests.cs
+++ b/tests/LightResults.Tests/ResultTValueTests.cs
@@ -144,6 +144,31 @@ public sealed class ResultTValueTests
     }
 
     [Fact]
+    public void IsSuccess_WhenResultIsFailure_ShouldReturnDefaultValueAndFirstOrEmptyError()
+    {
+        // Arrange
+        var firstError = new Error("Error 1");
+        var errors = new List<IError>
+        {
+            firstError,
+            new Error("Error 2"),
+        };
+
+        // Act
+        var isSuccess = Result.Failure<int>(errors).IsSuccess(out var resultValue, out var resultError);
+
+        // Assert
+        isSuccess.ShouldBeFalse();
+        resultValue.ShouldBe(default(int));
+        resultError.ShouldBe(firstError);
+
+        Result<int> defaultResult = default;
+        defaultResult.IsSuccess(out var defaultValue, out var defaultError).ShouldBeFalse();
+        defaultValue.ShouldBe(default(int));
+        defaultError.ShouldBeEquivalentTo(EmptyError);
+    }
+
+    [Fact]
     public void IsSuccess_WhenResultIsFailure_ShouldReturnNullValueAndFirstError()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- add an IsSuccess test for failure results with error lists to ensure default values and first errors are returned
- verify default-constructed results surface Error.Empty when IsSuccess is called with out parameters


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921fdf696a083289d9e0bcbaecd0395)