### PR TITLE
Add exception metadata tests for error constructors

### DIFF
--- a/tests/LightResults.Tests/ErrorTests.cs
+++ b/tests/LightResults.Tests/ErrorTests.cs
@@ -366,4 +366,62 @@ public sealed class ErrorTests
         // Assert
         error.Exception.ShouldBeNull();
     }
+
+    [Fact]
+    public void ExceptionProperty_ShouldReturnExceptionFromReadOnlyDictionaryMetadata()
+    {
+        // Arrange
+        var exception = new InvalidOperationException();
+        IReadOnlyDictionary<string, object?> metadata = new Dictionary<string, object?>
+        {
+            { "Exception", exception },
+        };
+        var error = new Error("error", metadata);
+
+        // Assert
+        error.Exception.ShouldBe(exception);
+    }
+
+    [Fact]
+    public void ExceptionProperty_ShouldReturnNullWhenReadOnlyDictionaryMetadataIsNotException()
+    {
+        // Arrange
+        IReadOnlyDictionary<string, object?> metadata = new Dictionary<string, object?>
+        {
+            { "Exception", "not exception" },
+        };
+        var error = new Error("error", metadata);
+
+        // Assert
+        error.Exception.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExceptionProperty_ShouldReturnExceptionFromEnumerableMetadata()
+    {
+        // Arrange
+        var exception = new InvalidOperationException();
+        IEnumerable<KeyValuePair<string, object?>> metadata = new[]
+        {
+            new KeyValuePair<string, object?>("Exception", exception),
+        };
+        var error = new Error("error", metadata);
+
+        // Assert
+        error.Exception.ShouldBe(exception);
+    }
+
+    [Fact]
+    public void ExceptionProperty_ShouldReturnNullWhenEnumerableMetadataIsNotException()
+    {
+        // Arrange
+        IEnumerable<KeyValuePair<string, object?>> metadata = new[]
+        {
+            new KeyValuePair<string, object?>("Exception", "not exception"),
+        };
+        var error = new Error("error", metadata);
+
+        // Assert
+        error.Exception.ShouldBeNull();
+    }
 }


### PR DESCRIPTION
## Summary
- add Exception property coverage for Error constructors using IReadOnlyDictionary and IEnumerable metadata
- confirm non-exception metadata leaves Exception property null

## Testing
- dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net10.0


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921fe0059c4832881ed974b25b88bc8)