### PR TITLE
Add reset coverage for single-item metadata enumerators

### DIFF
--- a/tests/LightResults.Tests/SingleItemMetadataDictionaryTests.cs
+++ b/tests/LightResults.Tests/SingleItemMetadataDictionaryTests.cs
@@ -84,6 +84,66 @@ public sealed class SingleItemMetadataDictionaryTests
             .ShouldBeFalse();
     }
 
+    [Fact]
+    public void Enumerators_Reset_ShouldReplaySingleItemWithoutAllocations()
+    {
+        // Arrange
+        var dictionary = CreateDictionary();
+
+        using var entryEnumerator = dictionary.GetEnumerator();
+        using var keyEnumerator = dictionary.Keys.GetEnumerator();
+        using var valueEnumerator = dictionary.Values.GetEnumerator();
+
+        // Act & Assert
+        entryEnumerator.GetType().IsValueType.ShouldBeTrue();
+        keyEnumerator.GetType().IsValueType.ShouldBeTrue();
+        valueEnumerator.GetType().IsValueType.ShouldBeTrue();
+
+        entryEnumerator.MoveNext()
+            .ShouldBeTrue();
+        entryEnumerator.Current.Key.ShouldBe(StoredKey);
+        entryEnumerator.Current.Value.ShouldBe(StoredValue);
+        entryEnumerator.MoveNext()
+            .ShouldBeFalse();
+
+        entryEnumerator.Reset();
+
+        entryEnumerator.MoveNext()
+            .ShouldBeTrue();
+        entryEnumerator.Current.Key.ShouldBe(StoredKey);
+        entryEnumerator.Current.Value.ShouldBe(StoredValue);
+        entryEnumerator.MoveNext()
+            .ShouldBeFalse();
+
+        keyEnumerator.MoveNext()
+            .ShouldBeTrue();
+        keyEnumerator.Current.ShouldBe(StoredKey);
+        keyEnumerator.MoveNext()
+            .ShouldBeFalse();
+
+        keyEnumerator.Reset();
+
+        keyEnumerator.MoveNext()
+            .ShouldBeTrue();
+        keyEnumerator.Current.ShouldBe(StoredKey);
+        keyEnumerator.MoveNext()
+            .ShouldBeFalse();
+
+        valueEnumerator.MoveNext()
+            .ShouldBeTrue();
+        valueEnumerator.Current.ShouldBe(StoredValue);
+        valueEnumerator.MoveNext()
+            .ShouldBeFalse();
+
+        valueEnumerator.Reset();
+
+        valueEnumerator.MoveNext()
+            .ShouldBeTrue();
+        valueEnumerator.Current.ShouldBe(StoredValue);
+        valueEnumerator.MoveNext()
+            .ShouldBeFalse();
+    }
+
     private static IReadOnlyDictionary<string, object?> CreateDictionary()
     {
         var type = typeof(Result).Assembly.GetType("LightResults.Common.SingleItemMetadataDictionary")!;


### PR DESCRIPTION
## Summary
- add coverage for resetting single-item metadata dictionary enumerators and replaying the entry
- assert key, value, and entry enumerators remain value types across repeated iterations

## Testing
- dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net10.0

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921fe0435d483289b97facd7a599761)