### PR TITLE
Add test for null success generic value

### DIFF
--- a/tests/LightResults.Tests/ResultTValueTests.cs
+++ b/tests/LightResults.Tests/ResultTValueTests.cs
@@ -391,6 +391,21 @@ public sealed class ResultTValueTests
     }
 
     [Fact]
+    public void Success_WithNullValue_ShouldCreateSuccessResultWithNullValue()
+    {
+        // Act
+        var result = Result.Success<object?>(null);
+
+        // Assert
+        result.IsSuccess().ShouldBeTrue();
+        result.IsSuccess(out var resultValue, out var resultError).ShouldBeTrue();
+        resultValue.ShouldBeNull();
+        resultError.ShouldBeNull();
+        result.IsFailure().ShouldBeFalse();
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void Failure_ShouldCreateFailureResultWithSingleError()
     {
         // Act


### PR DESCRIPTION
## Summary
- add a unit test covering Result.Success<object?>(null)
- verify success/failure flags, out parameters, and errors collection for null values

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69220434c60c83288cad95c127f824b7)