### PR TITLE
Add success test for default value results

### DIFF
--- a/tests/LightResults.Tests/ResultTValueTests.cs
+++ b/tests/LightResults.Tests/ResultTValueTests.cs
@@ -391,6 +391,24 @@ public sealed class ResultTValueTests
     }
 
     [Fact]
+    public void Success_WithDefaultValue_ShouldCreateSuccessResultWithValue()
+    {
+        // Arrange
+        const int value = 0;
+
+        // Act
+        var result = Result.Success(value);
+
+        // Assert
+        result.IsSuccess().ShouldBeTrue();
+        result.IsSuccess(out var resultValue, out var resultError).ShouldBeTrue();
+        resultValue.ShouldBe(value);
+        resultError.ShouldBeNull();
+        result.IsFailure().ShouldBeFalse();
+        result.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void Failure_ShouldCreateFailureResultWithSingleError()
     {
         // Act


### PR DESCRIPTION
## Summary
- add coverage for success Result<int> created with default value
- verify IsSuccess/IsFailure and errors behave correctly with default value

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692204368b64832890446abeefb408e8)