### PR TITLE
Add test for exception metadata fallback

### DIFF
--- a/tests/LightResults.Tests/ErrorTests.cs
+++ b/tests/LightResults.Tests/ErrorTests.cs
@@ -368,6 +368,22 @@ public sealed class ErrorTests
     }
 
     [Fact]
+    public void ExceptionProperty_ShouldPreserveMetadataWhenValueIsNotException()
+    {
+        // Arrange
+        const string metadataValue = "not exception";
+        var error = new Error("error", ("Exception", metadataValue));
+
+        // Act
+        var exception = error.Exception;
+
+        // Assert
+        exception.ShouldBeNull();
+        error.Metadata.Count.ShouldBe(1);
+        error.Metadata.Single().Value.ShouldBe(metadataValue);
+    }
+
+    [Fact]
     public void ExceptionProperty_ShouldReturnExceptionFromReadOnlyDictionaryMetadata()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- add a unit test covering the Error.Exception fallback path when the Exception metadata value is not an Exception
- verify the metadata entry remains present while Exception returns null

## Testing
- dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net10.0


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692204394b9483289346e708d4d96de4)