### PR TITLE
Add implicit conversion tests

### DIFF
--- a/tests/LightResults.Tests/ImplicitOperatorTests.cs
+++ b/tests/LightResults.Tests/ImplicitOperatorTests.cs
@@ -1,0 +1,101 @@
+using Shouldly;
+
+namespace LightResults.Tests;
+
+public sealed class ImplicitOperatorTests
+{
+    [Fact]
+    public void ImplicitErrorConversion_ToResult_ShouldBeFailureWithMetadata()
+    {
+        // Arrange
+        var error = new Error("boom", new KeyValuePair<string, object?>("CorrelationId", "123"));
+
+        // Act
+        Result result = error;
+
+        // Assert
+        result.IsFailure().ShouldBeTrue();
+        result.IsFailure(out var convertedError).ShouldBeTrue();
+        convertedError.ShouldBe(error);
+
+        var storedError = result.Errors.ShouldHaveSingleItem();
+        storedError.Message.ShouldBe("boom");
+        storedError.Metadata.ShouldContainKey("CorrelationId");
+        storedError.Metadata["CorrelationId"].ShouldBe("123");
+    }
+
+    [Fact]
+    public void ImplicitErrorConversion_ToResultOfT_ShouldBeFailureWithMetadata()
+    {
+        // Arrange
+        var error = new Error("boom", new KeyValuePair<string, object?>("CorrelationId", "456"));
+
+        // Act
+        Result<int> result = error;
+
+        // Assert
+        result.IsFailure().ShouldBeTrue();
+        result.IsFailure(out var convertedError).ShouldBeTrue();
+        convertedError.ShouldBe(error);
+
+        var storedError = result.Errors.ShouldHaveSingleItem();
+        storedError.Message.ShouldBe("boom");
+        storedError.Metadata.ShouldContainKey("CorrelationId");
+        storedError.Metadata["CorrelationId"].ShouldBe("456");
+    }
+
+    [Fact]
+    public void ImplicitValueConversion_ToResultOfT_ShouldSucceedForPrimitive()
+    {
+        // Act
+        Result<int> result = 42;
+
+        // Assert
+        result.IsSuccess().ShouldBeTrue();
+        result.IsSuccess(out var value).ShouldBeTrue();
+        value.ShouldBe(42);
+        result.IsFailure().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ImplicitValueConversion_ToResultOfT_ShouldTreatDefaultValueTypeAsSuccess()
+    {
+        // Act
+        Result<int> result = 0;
+
+        // Assert
+        result.IsSuccess().ShouldBeTrue();
+        result.IsSuccess(out var value).ShouldBeTrue();
+        value.ShouldBe(0);
+        result.IsFailure().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ImplicitValueConversion_ToResultOfT_ShouldHandleReferenceValues()
+    {
+        // Act
+        Result<string> result = "hello";
+
+        // Assert
+        result.IsSuccess().ShouldBeTrue();
+        result.IsSuccess(out var value).ShouldBeTrue();
+        value.ShouldBe("hello");
+        result.IsFailure().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ImplicitValueConversion_ToResultOfT_ShouldAllowNullReferences()
+    {
+        // Arrange
+        string? nullValue = null;
+
+        // Act
+        Result<string?> result = nullValue;
+
+        // Assert
+        result.IsSuccess().ShouldBeTrue();
+        result.IsSuccess(out var value).ShouldBeTrue();
+        value.ShouldBeNull();
+        result.IsFailure().ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests covering implicit conversions from Error to Result and Result<T>
- verify implicit conversions from primitive and reference values, including default and null values, produce successes

## Testing
- dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net10.0

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922043d25cc8328811394c2209458aa)