### PR TITLE
Add implicit conversion coverage for results

### DIFF
--- a/tests/LightResults.Tests/ResultTValueTests.cs
+++ b/tests/LightResults.Tests/ResultTValueTests.cs
@@ -779,6 +779,46 @@ public sealed class ResultTValueTests
     }
 
     [Fact]
+    public void ImplicitCast_FromValue_ShouldReflectSuccessState()
+    {
+        // Arrange
+        const string value = "Implicit value";
+
+        // Act
+        Result<string> result = value;
+        var expected = Result.Success(value);
+
+        // Assert
+        result.IsSuccess().ShouldBeTrue();
+        result.IsFailure().ShouldBeFalse();
+        result.IsSuccess(out var resultValue).ShouldBeTrue();
+        resultValue.ShouldBe(value);
+
+        result.Equals(expected).ShouldBeTrue();
+        result.GetHashCode().ShouldBe(expected.GetHashCode());
+        result.ToString().ShouldBe("Result { IsSuccess = True, Value = \"Implicit value\" }");
+    }
+
+    [Fact]
+    public void ImplicitCast_FromError_ShouldPropagateErrorToGenericResult()
+    {
+        // Arrange
+        var validationError = new ValidationError("Validation failed");
+
+        // Act
+        Result<Guid> result = validationError;
+        var expected = Result.Failure<Guid>(validationError);
+
+        // Assert
+        result.IsFailure().ShouldBeTrue();
+        result.HasError<ValidationError>().ShouldBeTrue();
+        result.Errors.ShouldHaveSingleItem().ShouldBeEquivalentTo(validationError);
+
+        result.Equals(expected).ShouldBeTrue();
+        result.ToString().ShouldBe("Result { IsSuccess = False, Error = \"Validation failed\" }");
+    }
+
+    [Fact]
     public void Equals_ResultInt_ShouldReturnTrueForEqualResults()
     {
         // Arrange

--- a/tests/LightResults.Tests/ResultTests.cs
+++ b/tests/LightResults.Tests/ResultTests.cs
@@ -1008,6 +1008,34 @@ public sealed class ResultTests
     }
 
     [Fact]
+    public void ImplicitCast_FromError_ShouldPreserveEqualityAndHashCode()
+    {
+        // Arrange
+        var implicitError = new Error("Implicit conversion error", ("Code", 404));
+
+        // Act
+        Result result = implicitError;
+        var expected = Result.Failure(implicitError);
+
+        // Assert
+        result.IsFailure()
+            .ShouldBeTrue();
+        result.HasError<Error>()
+            .ShouldBeTrue();
+        result.Errors.ShouldHaveSingleItem()
+            .ShouldBeEquivalentTo(implicitError);
+
+        result.Equals(expected)
+            .ShouldBeTrue();
+        (result == expected)
+            .ShouldBeTrue();
+        (result != expected)
+            .ShouldBeFalse();
+        result.GetHashCode()
+            .ShouldBe(expected.GetHashCode());
+    }
+
+    [Fact]
     public void Equals_Result_ShouldReturnTrueForEqualResults()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- add coverage for implicit Error-to-Result conversion including equality and hash code checks
- verify implicit conversions to Result<TValue> preserve success values and propagate errors with metadata and formatting

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922043f17c88328bba5e7732b07f720)