### PR TITLE
Add tests covering null exceptions in Error constructors

### DIFF
--- a/tests/LightResults.Tests/ErrorTests.cs
+++ b/tests/LightResults.Tests/ErrorTests.cs
@@ -177,6 +177,33 @@ public sealed class ErrorTests
     }
 
     [Fact]
+    public void ConstructorWithNullException_ShouldCreateEmptyError()
+    {
+        // Arrange & Act
+        var error = new Error((Exception?)null);
+
+        // Assert
+        error.Message.ShouldBeEmpty();
+        error.Metadata.Count.ShouldBe(0);
+        error.Exception.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ConstructorWithMessageAndNullException_ShouldPreserveMessage()
+    {
+        // Arrange
+        const string errorMessage = "Sample error message";
+
+        // Act
+        var error = new Error(errorMessage, (Exception?)null);
+
+        // Assert
+        error.Message.ShouldBe(errorMessage);
+        error.Metadata.Count.ShouldBe(0);
+        error.Exception.ShouldBeNull();
+    }
+
+    [Fact]
     public void ConstructorWithMessageAndException_ShouldCreateErrorWithMessageAndMetadata()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- add xUnit cases for null exception inputs to Error constructors
- assert message preservation, empty metadata, and null exception values

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922043fc5fc8328a4fc43a1852ebf65)