### PR TITLE
Opt into Microsoft.Testing.Platform for .NET 10 tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ multiple frameworks (net8.0–net10.0) and relies heavily on low-allocation tech
   - `Error.cs` – immutable error type.
   - `IResult.cs`, `IResult\`1.cs`, `IError.cs` – API contracts.
   - `Common/` – helper utilities and optional interfaces when targeting newer frameworks.
-- `tests/LightResults.Tests` – xUnit tests for the library.
+- `tests/LightResults.Tests` – TUnit tests for the library (native AOT test host enabled and configured for the Microsoft.Testing.Platform runner).
 - `docfx/` – documentation generation config.
 - `LightResults.sln` – solution file.
 
@@ -39,7 +39,7 @@ The project uses the standard .NET SDK. When a .NET environment is available you
 # Restore and build
  dotnet build LightResults.sln
 
-# Run tests
+# Run tests (TUnit with the Native AOT test host)
  dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net10.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Several [extensions are available](https://github.com/jscarle/LightResults.Exten
 
 Make sure to [read the docs](https://jscarle.github.io/LightResults/) for the full API.
 
+## Testing
+
+The test suite uses [TUnit](https://www.nuget.org/packages/TUnit) with the native AOT test host enabled via `UseNativeAotForTestHost`.
+Run the tests with `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net10.0` (the repository opts into the .NET 10 Microsoft.Testing.Platform experience via `UseMicrosoftTestingPlatform` and a `global.json` manifest).
+
 ## Getting Started
 
 LightResults centers on three primary types `Result`, `Result<TValue>`, and `Error`.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,8 @@
+{
+  "sdk": {
+    "version": "10.0.100"
+  },
+  "msbuild-sdks": {
+    "Microsoft.Testing.Platform.Manifest-10.0.100": "2.0.1"
+  }
+}

--- a/tests/LightResults.Tests/ActionableResultTests.cs
+++ b/tests/LightResults.Tests/ActionableResultTests.cs
@@ -84,7 +84,7 @@ public sealed class ActionableResultEdgeTests
         public bool HasError<TError>([MaybeNullWhen(false)] out TError error) where TError : IError => _inner.HasError(out error);
     }
 
-    [Fact]
+    [Test]
     public void CustomActionableResult_Success_ShouldCreateSuccessResult()
     {
         // Act
@@ -95,7 +95,7 @@ public sealed class ActionableResultEdgeTests
         result.IsFailure().ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void CustomActionableResult_Failure_ShouldCreateFailureResult()
     {
         // Act
@@ -107,8 +107,8 @@ public sealed class ActionableResultEdgeTests
         result.Errors.ShouldHaveSingleItem();
     }
 
-    [Theory]
-    [MemberData(nameof(FailureMetadataCases))]
+    [Test]
+    [MethodDataSource(nameof(FailureMetadataCases))]
     public void CustomActionableResult_Failure_WithMetadata_ShouldPropagateMetadata(
         CustomResult result,
         string expectedKey,
@@ -129,8 +129,8 @@ public sealed class ActionableResultEdgeTests
         result.HasError<CustomError>(out _).ShouldBeFalse();
     }
 
-    [Theory]
-    [MemberData(nameof(FailureExceptionCases))]
+    [Test]
+    [MethodDataSource(nameof(FailureExceptionCases))]
     public void CustomActionableResult_Failure_WithException_ShouldExposeException(
         CustomResult result,
         Exception exception)
@@ -151,7 +151,7 @@ public sealed class ActionableResultEdgeTests
         result.HasError<CustomError>(out _).ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void CustomActionableResult_Failure_WithSingleError_ShouldPropagateError()
     {
         // Arrange
@@ -172,8 +172,8 @@ public sealed class ActionableResultEdgeTests
         result.HasError<AnotherCustomError>(out _).ShouldBeFalse();
     }
 
-    [Theory]
-    [MemberData(nameof(FailureEnumerableErrorsCases))]
+    [Test]
+    [MethodDataSource(nameof(FailureEnumerableErrorsCases))]
     public void CustomActionableResult_Failure_WithEnumerableErrors_ShouldPropagateErrors(
         CustomResult result,
         IReadOnlyList<IError> expectedErrors)

--- a/tests/LightResults.Tests/CustomErrorTests.cs
+++ b/tests/LightResults.Tests/CustomErrorTests.cs
@@ -4,7 +4,7 @@ namespace LightResults.Tests;
 
 public sealed class CustomErrorTests
 {
-    [Fact]
+    [Test]
     public void DefaultConstructor_ShouldCreateEmptyCustomError()
     {
         // Arrange
@@ -15,7 +15,7 @@ public sealed class CustomErrorTests
         error.Metadata.ShouldBeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void ConstructorWithMessage_ShouldCreateErrorWithMessage()
     {
         // Arrange
@@ -29,7 +29,7 @@ public sealed class CustomErrorTests
         error.Metadata.ShouldBeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void ConstructorWithMessageAndMetadataDictionary_ShouldCreateErrorWithMessageAndMultipleMetadata()
     {
         // Arrange
@@ -49,9 +49,9 @@ public sealed class CustomErrorTests
         error.Metadata.ShouldBe(metadata);
     }
 
-    [Theory]
-    [InlineData("")]
-    [InlineData("An unknown error occurred!")]
+    [Test]
+    [Arguments("")]
+    [Arguments("An unknown error occurred!")]
     public void ToString_ShouldReturnStringRepresentation(string errorMessage)
     {
         // Arrange

--- a/tests/LightResults.Tests/ErrorTests.cs
+++ b/tests/LightResults.Tests/ErrorTests.cs
@@ -5,7 +5,7 @@ namespace LightResults.Tests;
 
 public sealed class ErrorTests
 {
-    [Fact]
+    [Test]
     public void DefaultConstructor_ShouldCreateEmptyError()
     {
         // Arrange
@@ -16,7 +16,7 @@ public sealed class ErrorTests
         error.Metadata.ShouldBeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void ConstructorWithMessage_ShouldCreateErrorWithMessage()
     {
         // Arrange
@@ -30,7 +30,7 @@ public sealed class ErrorTests
         error.Metadata.ShouldBeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void ConstructorWithMessageAndMetadataTuple_ShouldCreateErrorWithMessageAndMetadata()
     {
         // Arrange
@@ -48,7 +48,7 @@ public sealed class ErrorTests
         firstMetadata.Value.ShouldBe(metadata.Value);
     }
 
-    [Fact]
+    [Test]
     public void ConstructorWithMessageAndMetadataKeyValuePair_ShouldCreateErrorWithMessageAndMetadata()
     {
         // Arrange
@@ -66,7 +66,7 @@ public sealed class ErrorTests
         firstMetadata.Value.ShouldBe(metadata.Value);
     }
 
-    [Fact]
+    [Test]
     [SuppressMessage("ReSharper", "PossibleMultipleEnumeration")]
     public void ConstructorWithMessageAndMetadataIEnumerable_ShouldCreateErrorWithMessageAndMetadata()
     {
@@ -87,7 +87,7 @@ public sealed class ErrorTests
         error.Metadata.ShouldBe(metadata);
     }
 
-    [Fact]
+    [Test]
     public void ConstructorWithMessageAndMetadataDictionary_ShouldCreateErrorWithMessageAndMetadata()
     {
         // Arrange
@@ -107,7 +107,7 @@ public sealed class ErrorTests
         error.Metadata.ShouldBe(metadata);
     }
 
-    [Fact]
+    [Test]
     public void MessagePropertyInit_ShouldCreateErrorWithMessage()
     {
         // Arrange
@@ -122,7 +122,7 @@ public sealed class ErrorTests
         error.Metadata.ShouldBeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void MetadataPropertyInit_ShouldCreateErrorWithMetadata()
     {
         // Arrange
@@ -142,7 +142,7 @@ public sealed class ErrorTests
         error.Metadata.ShouldBe(metadata);
     }
 
-    [Fact]
+    [Test]
     public void ConstructorWithException_ShouldCreateErrorWithMessageAndMetadata()
     {
         // Arrange
@@ -159,7 +159,7 @@ public sealed class ErrorTests
         metadata.Value.ShouldBe(exception);
     }
 
-    [Fact]
+    [Test]
     public void ConstructorWithException_ShouldFallbackMessageWhenExceptionMessageIsEmpty()
     {
         // Arrange
@@ -176,7 +176,7 @@ public sealed class ErrorTests
         metadata.Value.ShouldBe(exception);
     }
 
-    [Fact]
+    [Test]
     public void ConstructorWithNullException_ShouldCreateEmptyError()
     {
         // Arrange & Act
@@ -188,7 +188,7 @@ public sealed class ErrorTests
         error.Exception.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void ConstructorWithMessageAndNullException_ShouldPreserveMessage()
     {
         // Arrange
@@ -203,7 +203,7 @@ public sealed class ErrorTests
         error.Exception.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void ConstructorWithMessageAndException_ShouldCreateErrorWithMessageAndMetadata()
     {
         // Arrange
@@ -221,9 +221,9 @@ public sealed class ErrorTests
         metadata.Value.ShouldBe(exception);
     }
 
-    [Theory]
-    [InlineData("")]
-    [InlineData("An unknown error occurred!")]
+    [Test]
+    [Arguments("")]
+    [Arguments("An unknown error occurred!")]
     public void ToString_ShouldReturnStringRepresentation(string errorMessage)
     {
         // Arrange
@@ -234,7 +234,7 @@ public sealed class ErrorTests
             .ShouldBe(errorMessage.Length > 0 ? $"Error {{ Message = \"{errorMessage}\" }}" : "Error");
     }
 
-    [Fact]
+    [Test]
     public void Equals_Error_ShouldReturnTrueForEqualErrors()
     {
         // Arrange
@@ -246,7 +246,7 @@ public sealed class ErrorTests
             .ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void Equals_Error_ShouldReturnFalseForUnequalErrors()
     {
         // Arrange
@@ -258,7 +258,7 @@ public sealed class ErrorTests
             .ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void Equals_Error_ShouldIgnoreMetadataOrderingButRespectKeys()
     {
         // Arrange
@@ -283,7 +283,7 @@ public sealed class ErrorTests
             .ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void Equals_Object_ShouldReturnTrueForEqualErrors()
     {
         // Arrange
@@ -295,7 +295,7 @@ public sealed class ErrorTests
             .ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void Equals_Object_ShouldReturnFalseForUnequalErrors()
     {
         // Arrange
@@ -307,7 +307,7 @@ public sealed class ErrorTests
             .ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void GetHashCode_ShouldReturnSameHashCodeForEqualErrors()
     {
         // Arrange
@@ -319,7 +319,7 @@ public sealed class ErrorTests
             .ShouldBe(error2.GetHashCode());
     }
 
-    [Fact]
+    [Test]
     public void op_Equality_Error_ShouldReturnTrueForEqualErrors()
     {
         // Arrange
@@ -330,7 +330,7 @@ public sealed class ErrorTests
         (error1 == error2).ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void op_Equality_Error_ShouldReturnFalseForUnequalErrors()
     {
         // Arrange
@@ -341,7 +341,7 @@ public sealed class ErrorTests
         (error1 == error2).ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void op_Inequality_Error_ShouldReturnFalseForEqualErrors()
     {
         // Arrange
@@ -352,7 +352,7 @@ public sealed class ErrorTests
         (error1 != error2).ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void op_Inequality_Error_ShouldReturnTrueForUnequalErrors()
     {
         // Arrange
@@ -363,7 +363,7 @@ public sealed class ErrorTests
         (error1 != error2).ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void ExceptionProperty_ShouldReturnExceptionWhenMetadataContainsException()
     {
         // Arrange
@@ -374,7 +374,7 @@ public sealed class ErrorTests
         error.Exception.ShouldBe(exception);
     }
 
-    [Fact]
+    [Test]
     public void ExceptionProperty_ShouldReturnNullWhenMetadataDoesNotContainException()
     {
         // Arrange
@@ -384,7 +384,7 @@ public sealed class ErrorTests
         error.Exception.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void ExceptionProperty_ShouldReturnNullWhenMetadataIsNotException()
     {
         // Arrange
@@ -394,7 +394,7 @@ public sealed class ErrorTests
         error.Exception.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void ExceptionProperty_ShouldPreserveMetadataWhenValueIsNotException()
     {
         // Arrange
@@ -410,7 +410,7 @@ public sealed class ErrorTests
         error.Metadata.Single().Value.ShouldBe(metadataValue);
     }
 
-    [Fact]
+    [Test]
     public void ExceptionProperty_ShouldReturnExceptionFromReadOnlyDictionaryMetadata()
     {
         // Arrange
@@ -425,7 +425,7 @@ public sealed class ErrorTests
         error.Exception.ShouldBe(exception);
     }
 
-    [Fact]
+    [Test]
     public void ExceptionProperty_ShouldReturnNullWhenReadOnlyDictionaryMetadataIsNotException()
     {
         // Arrange
@@ -439,7 +439,7 @@ public sealed class ErrorTests
         error.Exception.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void ExceptionProperty_ShouldReturnExceptionFromEnumerableMetadata()
     {
         // Arrange
@@ -454,7 +454,7 @@ public sealed class ErrorTests
         error.Exception.ShouldBe(exception);
     }
 
-    [Fact]
+    [Test]
     public void ExceptionProperty_ShouldReturnNullWhenEnumerableMetadataIsNotException()
     {
         // Arrange

--- a/tests/LightResults.Tests/LightResults.Tests.csproj
+++ b/tests/LightResults.Tests/LightResults.Tests.csproj
@@ -7,6 +7,9 @@
         <LangVersion>latest</LangVersion>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+        <UseNativeAotForTestHost>true</UseNativeAotForTestHost>
+        <UseVSTest>false</UseVSTest>
+        <UseMicrosoftTestingPlatform>true</UseMicrosoftTestingPlatform>
     </PropertyGroup>
 
     <ItemGroup>
@@ -14,22 +17,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
+        <Using Include="TUnit.Core" />
     </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
         <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="xunit.v3" Version="3.2.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="TUnit" Version="1.2.11" />
     </ItemGroup>
 
 </Project>

--- a/tests/LightResults.Tests/ResultTValueTests.cs
+++ b/tests/LightResults.Tests/ResultTValueTests.cs
@@ -10,7 +10,7 @@ public sealed class ResultTValueTests
 {
     private static readonly IError EmptyError = Error.Empty;
 
-    [Fact]
+    [Test]
     public void DefaultStruct_ShouldBeFailureResultWithDefaultValue()
     {
         // Arrange
@@ -33,7 +33,7 @@ public sealed class ResultTValueTests
         validationError.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void DefaultStruct_ShouldBeFailureResultWithNullValue()
     {
         // Arrange
@@ -56,7 +56,7 @@ public sealed class ResultTValueTests
         validationError.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void IsSuccess_WhenResultIsSuccess()
     {
         // Arrange
@@ -66,7 +66,7 @@ public sealed class ResultTValueTests
         result.IsSuccess().ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void IsSuccess_WhenResultIsSuccess_ShouldReturnAssignedValue()
     {
         // Arrange
@@ -80,7 +80,7 @@ public sealed class ResultTValueTests
         resultValue.ShouldBe(42);
     }
 
-    [Fact]
+    [Test]
     public void IsSuccess_WhenResultIsSuccess_ShouldReturnAssignedValueAndNullError()
     {
         // Arrange
@@ -95,7 +95,7 @@ public sealed class ResultTValueTests
         resultError.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void IsSuccess_WhenResultIsFailure_ShouldReturnDefaultValue()
     {
         // Arrange
@@ -109,7 +109,7 @@ public sealed class ResultTValueTests
         resultValue.ShouldBe(0);
     }
 
-    [Fact]
+    [Test]
     public void IsSuccess_WhenResultIsFailure_ShouldReturnNullValue()
     {
         // Arrange
@@ -123,7 +123,7 @@ public sealed class ResultTValueTests
         resultValue.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void IsSuccess_WhenResultIsFailure_ShouldReturnDefaultValueAndFirstError()
     {
         // Arrange
@@ -144,7 +144,7 @@ public sealed class ResultTValueTests
         resultError.ShouldBe(firstError);
     }
 
-    [Fact]
+    [Test]
     public void IsSuccess_WhenResultIsFailure_ShouldReturnDefaultValueAndFirstOrEmptyError()
     {
         // Arrange
@@ -169,7 +169,7 @@ public sealed class ResultTValueTests
         defaultError.ShouldBeEquivalentTo(EmptyError);
     }
 
-    [Fact]
+    [Test]
     public void IsSuccess_WhenResultIsFailure_ShouldReturnNullValueAndFirstError()
     {
         // Arrange
@@ -190,7 +190,7 @@ public sealed class ResultTValueTests
         resultError.ShouldBe(firstError);
     }
 
-    [Fact]
+    [Test]
     public void IsSuccess_WhenResultIsFailure_ShouldReturnDefaultValueAndDefaultError()
     {
         // Arrange
@@ -205,7 +205,7 @@ public sealed class ResultTValueTests
         resultError.ShouldBeEquivalentTo(EmptyError);
     }
 
-    [Fact]
+    [Test]
     public void IsFailure_WhenResultIsFailure()
     {
         // Arrange
@@ -215,7 +215,7 @@ public sealed class ResultTValueTests
         result.IsFailure().ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void IsFailure_WhenResultIsFailure_ShouldReturnFirstError()
     {
         // Arrange
@@ -235,7 +235,7 @@ public sealed class ResultTValueTests
         resultError.ShouldBe(firstError);
     }
 
-    [Fact]
+    [Test]
     public void IsFailure_WithErrorAndValueOutParameters_ShouldReturnFalseForSuccess()
     {
         // Arrange
@@ -250,7 +250,7 @@ public sealed class ResultTValueTests
         error.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void IsFailure_WithErrorAndValueOutParameters_ShouldReturnTrueAndFirstError()
     {
         // Arrange
@@ -271,7 +271,7 @@ public sealed class ResultTValueTests
         error.ShouldBe(firstError);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithICollection_ShouldCopyErrorsInOrderOnce()
     {
         // Arrange
@@ -287,7 +287,7 @@ public sealed class ResultTValueTests
         errors.CopyToCallCount.ShouldBe(1);
     }
 
-    [Fact]
+    [Test]
     public void IsFailure_WithErrorAndValueOutParameters_ShouldReturnEmptyErrorForDefaultStruct()
     {
         // Arrange
@@ -302,7 +302,7 @@ public sealed class ResultTValueTests
         error.ShouldBeEquivalentTo(EmptyError);
     }
 
-    [Fact]
+    [Test]
     public void IsFailure_WhenResultIsSuccess_ShouldReturnNullError()
     {
         // Arrange
@@ -316,7 +316,7 @@ public sealed class ResultTValueTests
         resultError.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void IsFailure_WhenResultIsFailure_ShouldReturnFirstErrorAndDefaultValue()
     {
         // Arrange
@@ -337,7 +337,7 @@ public sealed class ResultTValueTests
         resultValue.ShouldBe(0);
     }
 
-    [Fact]
+    [Test]
     public void IsFailure_WhenResultIsFailure_ShouldReturnFirstErrorAndNullValue()
     {
         // Arrange
@@ -358,7 +358,7 @@ public sealed class ResultTValueTests
         resultValue.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void IsFailure_WhenResultIsFailure_ShouldReturnDefaultErrorAndNullValue()
     {
         // Arrange
@@ -373,7 +373,7 @@ public sealed class ResultTValueTests
         resultValue.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void IsFailure_WhenResultIsSuccess_ShouldReturnNullErrorAndAssignedValue()
     {
         // Arrange
@@ -388,7 +388,7 @@ public sealed class ResultTValueTests
         resultValue.ShouldBe(42);
     }
 
-    [Fact]
+    [Test]
     public void Success_WithValue_ShouldCreateSuccessResultWithValue()
     {
         // Arrange
@@ -407,7 +407,7 @@ public sealed class ResultTValueTests
         result.Errors.ShouldBeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void Success_WithNullValue_ShouldCreateSuccessResultWithNullValue()
     {
         // Act
@@ -422,7 +422,7 @@ public sealed class ResultTValueTests
         result.Errors.ShouldBeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void Failure_ShouldCreateFailureResultWithSingleError()
     {
         // Act
@@ -437,7 +437,7 @@ public sealed class ResultTValueTests
         result.Errors.Single().Message.ShouldBe("");
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithErrorMessage_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -455,7 +455,7 @@ public sealed class ResultTValueTests
         result.Errors.Single().Message.ShouldBe(errorMessage);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithErrorMessageAndTupleMetadata_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -477,7 +477,7 @@ public sealed class ResultTValueTests
         error.Metadata.Single().ShouldBeEquivalentTo(new KeyValuePair<string, object?>("Key", 0));
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithErrorMessageAndDictionaryMetadata_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -502,7 +502,7 @@ public sealed class ResultTValueTests
         error.Metadata.Single().ShouldBeEquivalentTo(new KeyValuePair<string, object?>("Key", 0));
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithErrorObject_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -520,7 +520,7 @@ public sealed class ResultTValueTests
         result.Errors.Single().ShouldBeEquivalentTo(error);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithErrorsEnumerable_ShouldCreateFailureResultWithMultipleErrors()
     {
         // Arrange
@@ -542,7 +542,7 @@ public sealed class ResultTValueTests
         result.Errors.ShouldBe(errors);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithErrorsEnumerable_ShouldReuseListInstance()
     {
         // Arrange
@@ -559,7 +559,7 @@ public sealed class ResultTValueTests
         result.Errors.ShouldBeSameAs(errors);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithEmptyErrorsEnumerable_ShouldCreateFailureWithoutErrors()
     {
         // Arrange
@@ -581,7 +581,7 @@ public sealed class ResultTValueTests
         validationError.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithErrorsReadOnlyList_ShouldCreateFailureResultWithMultipleErrors()
     {
         // Arrange
@@ -603,7 +603,7 @@ public sealed class ResultTValueTests
         result.Errors.ShouldBe(errors);
     }
 
-    [Fact]
+    [Test]
     public void HasError_WithMatchingErrorType_ShouldReturnTrue()
     {
         // Arrange
@@ -613,7 +613,7 @@ public sealed class ResultTValueTests
         result.HasError<ValidationError>().ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void HasError_WithMatchingErrorType_ShouldOutFirstMatch()
     {
         // Arrange
@@ -633,7 +633,7 @@ public sealed class ResultTValueTests
         error.ShouldBe(firstError);
     }
 
-    [Fact]
+    [Test]
     public void HasError_WithNonMatchingErrorType_ShouldReturnFalse()
     {
         // Arrange
@@ -643,7 +643,7 @@ public sealed class ResultTValueTests
         result.HasError<ValidationError>().ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void HasError_WithNonMatchingErrorType_ShouldOutDefaultError()
     {
         // Arrange
@@ -657,7 +657,7 @@ public sealed class ResultTValueTests
         error.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void HasError_WhenIsSuccess_ShouldReturnFalse()
     {
         // Arrange
@@ -667,7 +667,7 @@ public sealed class ResultTValueTests
         result.HasError<ValidationError>().ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void HasError_WhenIsSuccess_ShouldOutDefaultError()
     {
         // Arrange
@@ -681,7 +681,7 @@ public sealed class ResultTValueTests
         error.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void ImplicitOperator_ShouldCreateSuccessResultWithValue()
     {
         // Arrange
@@ -699,7 +699,7 @@ public sealed class ResultTValueTests
         result.Errors.ShouldBeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void AsFailure_ShouldConvertResultToNonGenericResultWithSameErrors()
     {
         // Arrange
@@ -720,7 +720,7 @@ public sealed class ResultTValueTests
         nonGenericResult.Errors.ShouldBe(errors);
     }
 
-    [Fact]
+    [Test]
     public void AsFailure_ShouldConvertDefaultResultToNonGenericResult()
     {
         // Arrange
@@ -736,7 +736,7 @@ public sealed class ResultTValueTests
         nonGenericResult.Errors.Single().ShouldBeEquivalentTo(EmptyError);
     }
 
-    [Fact]
+    [Test]
     public void AsFailure_ShouldConvertResultToGenericResultWithSameErrors()
     {
         // Arrange
@@ -757,7 +757,7 @@ public sealed class ResultTValueTests
         genericResult.Errors.ShouldBe(errors);
     }
 
-    [Fact]
+    [Test]
     public void AsFailure_ShouldConvertDefaultResultToGenericResult()
     {
         // Arrange
@@ -773,7 +773,7 @@ public sealed class ResultTValueTests
         genericResult.Errors.Single().ShouldBeEquivalentTo(EmptyError);
     }
 
-    [Fact]
+    [Test]
     public void ImplicitCast_ShouldCreateSuccessResultFromValue()
     {
         // Arrange
@@ -791,7 +791,7 @@ public sealed class ResultTValueTests
         result.Errors.ShouldBeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void ImplicitCast_ShouldCreateFailureResultFromError()
     {
         // Arrange
@@ -810,7 +810,7 @@ public sealed class ResultTValueTests
         result.Errors.Single().ShouldBeEquivalentTo(error);
     }
 
-    [Fact]
+    [Test]
     public void ImplicitCast_FromValue_ShouldReflectSuccessState()
     {
         // Arrange
@@ -831,7 +831,7 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe("Result { IsSuccess = True, Value = \"Implicit value\" }");
     }
 
-    [Fact]
+    [Test]
     public void ImplicitCast_FromError_ShouldPropagateErrorToGenericResult()
     {
         // Arrange
@@ -848,7 +848,7 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe("Result { IsSuccess = False, Error = \"Validation failed\" }");
     }
 
-    [Fact]
+    [Test]
     public void Equals_ResultInt_ShouldReturnTrueForEqualResults()
     {
         // Arrange
@@ -859,7 +859,7 @@ public sealed class ResultTValueTests
         result1.Equals(result2).ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void Equals_ResultInt_ShouldReturnFalseForDifferentResults()
     {
         // Arrange
@@ -870,7 +870,7 @@ public sealed class ResultTValueTests
         result1.Equals(result2).ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void Equals_ResultObject_ShouldReturnTrueForEqualResults()
     {
         // Arrange
@@ -881,7 +881,7 @@ public sealed class ResultTValueTests
         result1.Equals(result2).ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void Equals_ResultObject_ShouldReturnFalseForDifferentResults()
     {
         // Arrange
@@ -892,7 +892,7 @@ public sealed class ResultTValueTests
         result1.Equals(result2).ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void Equals_ResultIntToObject_ShouldReturnFalseForDifferentResults()
     {
         // Arrange
@@ -903,7 +903,7 @@ public sealed class ResultTValueTests
         result1.Equals(result2).ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void GetHashCode_ResultInt_ShouldReturnSameHashCodeForEqualResults()
     {
         // Arrange
@@ -914,7 +914,7 @@ public sealed class ResultTValueTests
         result1.GetHashCode().ShouldBe(result2.GetHashCode());
     }
 
-    [Fact]
+    [Test]
     public void GetHashCode_ResultInt_ShouldReturnDifferentHashCodeForDifferentResults()
     {
         // Arrange
@@ -925,7 +925,7 @@ public sealed class ResultTValueTests
         result1.GetHashCode().ShouldNotBe(result2.GetHashCode());
     }
 
-    [Fact]
+    [Test]
     public void op_Equality_ResultInt_ShouldReturnTrueForEqualResults()
     {
         // Arrange
@@ -936,7 +936,7 @@ public sealed class ResultTValueTests
         (result1 == result2).ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void op_Equality_ResultInt_ShouldReturnFalseForDifferentResults()
     {
         // Arrange
@@ -947,7 +947,7 @@ public sealed class ResultTValueTests
         (result1 == result2).ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void op_Inequality_ResultInt_ShouldReturnFalseForEqualResults()
     {
         // Arrange
@@ -958,7 +958,7 @@ public sealed class ResultTValueTests
         (result1 != result2).ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void op_Inequality_ResultInt_ShouldReturnTrueForDifferentResults()
     {
         // Arrange
@@ -969,7 +969,7 @@ public sealed class ResultTValueTests
         (result1 != result2).ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void op_Equality_ResultObject_ShouldReturnTrueForEqualResults()
     {
         // Arrange
@@ -980,7 +980,7 @@ public sealed class ResultTValueTests
         (result1 == result2).ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void op_Equality_ResultObject_ShouldReturnFalseForDifferentResults()
     {
         // Arrange
@@ -991,7 +991,7 @@ public sealed class ResultTValueTests
         (result1 == result2).ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void op_Inequality_ResultObject_ShouldReturnFalseForEqualResults()
     {
         // Arrange
@@ -1002,7 +1002,7 @@ public sealed class ResultTValueTests
         (result1 != result2).ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void op_Inequality_ResultObject_ShouldReturnTrueForDifferentResults()
     {
         // Arrange
@@ -1013,7 +1013,7 @@ public sealed class ResultTValueTests
         (result1 != result2).ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void op_Equality_ResultIntToObject_ShouldReturnFalseForDifferentResults()
     {
         // Arrange
@@ -1024,7 +1024,7 @@ public sealed class ResultTValueTests
         (result1 == result2).ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void op_Inequality_ResultIntToObject_ShouldReturnTrueForDifferentResults()
     {
         // Arrange
@@ -1035,7 +1035,7 @@ public sealed class ResultTValueTests
         (result1 != result2).ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void Equals_Result_DefaultResults_ShouldReturnTrue()
     {
         // Arrange
@@ -1046,7 +1046,7 @@ public sealed class ResultTValueTests
         result1.Equals(result2).ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void GetHashCode_Result_DefaultResults_ShouldReturnSameHashCode()
     {
         // Arrange
@@ -1057,7 +1057,7 @@ public sealed class ResultTValueTests
         result1.GetHashCode().ShouldBe(result2.GetHashCode());
     }
 
-    [Fact]
+    [Test]
     public void Equals_Result_DefaultAndFailure_ShouldReturnFalse()
     {
         // Arrange
@@ -1068,7 +1068,7 @@ public sealed class ResultTValueTests
         result1.Equals(result2).ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void GetHashCode_Result_DefaultAndFailure_ShouldReturnDifferentHashCodes()
     {
         // Arrange
@@ -1079,10 +1079,10 @@ public sealed class ResultTValueTests
         result1.GetHashCode().ShouldNotBe(result2.GetHashCode());
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = True", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = True", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForBoolean(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1092,10 +1092,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 1", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 1", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForSByte(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1105,10 +1105,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 1", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 1", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForByte(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1118,10 +1118,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 1", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 1", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForInt16(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1131,10 +1131,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 1", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 1", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForUInt16(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1144,10 +1144,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 1", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 1", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForInt32(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1157,10 +1157,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 1", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 1", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForUInt32(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1170,10 +1170,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 1", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 1", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForInt64(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1183,10 +1183,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 1", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 1", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForUInt64(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1196,10 +1196,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 1.1", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 1.1", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForDecimal(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1209,10 +1209,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 1.1", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 1.1", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForFloat(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1222,10 +1222,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 1.1", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 1.1", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForDouble(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1235,10 +1235,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = \"2024-04-05T12:30:00Z\"", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = \"2024-04-05T12:30:00Z\"", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForDateTime(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1250,10 +1250,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = \"2024-04-05T12:30:00+00:00\"", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = \"2024-04-05T12:30:00+00:00\"", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForDateTimeOffset(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1265,10 +1265,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 'c'", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 'c'", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForChar(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1278,10 +1278,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = \"StringValue\"", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = \"StringValue\"", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForString(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1291,10 +1291,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForObject(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1304,10 +1304,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 1", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 1", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForNullableValueTypes(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1317,10 +1317,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 42", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 42", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForCustomFormattable(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1341,7 +1341,7 @@ public sealed class ResultTValueTests
 
     private class ValidationError(string errorMessage) : Error(errorMessage);
 
-    [Fact]
+    [Test]
     public void InterfaceSuccess_WithValue_ShouldCreateSuccessResultWithValue()
     {
         // Arrange
@@ -1366,7 +1366,7 @@ public sealed class ResultTValueTests
         result.Errors.ShouldBeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void InterfaceFailure_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -1388,7 +1388,7 @@ public sealed class ResultTValueTests
         result.Errors.Single().Message.ShouldBe("");
     }
 
-    [Fact]
+    [Test]
     public void InterfaceFailure_WithErrorMessage_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -1411,7 +1411,7 @@ public sealed class ResultTValueTests
         result.Errors.Single().Message.ShouldBe("Sample error message");
     }
 
-    [Fact]
+    [Test]
     public void InterfaceFailure_WithErrorMessageAndTupleMetadata_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -1437,7 +1437,7 @@ public sealed class ResultTValueTests
         error.Metadata.Single().ShouldBeEquivalentTo(new KeyValuePair<string, object?>("Key", 0));
     }
 
-    [Fact]
+    [Test]
     public void InterfaceFailure_WithErrorMessageAndKeyValuePairMetadata_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -1463,7 +1463,7 @@ public sealed class ResultTValueTests
         error.Metadata.Single().ShouldBeEquivalentTo(new KeyValuePair<string, object?>("Key", 0));
     }
 
-    [Fact]
+    [Test]
     public void InterfaceFailure_WithErrorMessageAndDictionaryMetadata_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -1492,7 +1492,7 @@ public sealed class ResultTValueTests
         error.Metadata.Single().ShouldBeEquivalentTo(new KeyValuePair<string, object?>("Key", 0));
     }
 
-    [Fact]
+    [Test]
     public void InterfaceFailure_WithErrorObject_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -1515,7 +1515,7 @@ public sealed class ResultTValueTests
         result.Errors.Single().ShouldBeEquivalentTo(new Error("Sample error"));
     }
 
-    [Fact]
+    [Test]
     public void InterfaceFailure_WithErrorsEnumerable_ShouldCreateFailureResultWithMultipleErrors()
     {
         // Arrange
@@ -1542,7 +1542,7 @@ public sealed class ResultTValueTests
         result.Errors.ShouldBeSameAs(errors);
     }
 
-    [Fact]
+    [Test]
     public void InterfaceFailure_WithErrorsReadOnlyList_ShouldCreateFailureResultWithMultipleErrors()
     {
         // Arrange
@@ -1573,10 +1573,10 @@ public sealed class ResultTValueTests
         });
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = \"2024-04-05\"", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = \"2024-04-05\"", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForDateOnly(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1586,10 +1586,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = \"12:30:00\"", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = \"12:30:00\"", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForTimeOnly(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1599,10 +1599,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 1", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 1", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForInt128(bool success, string expected, string errorMessage)
     {
         // Arrange
@@ -1612,10 +1612,10 @@ public sealed class ResultTValueTests
         result.ToString().ShouldBe($"Result {{ {expected} }}");
     }
 
-    [Theory]
-    [InlineData(true, "IsSuccess = True, Value = 1", "")]
-    [InlineData(false, "IsSuccess = False", "")]
-    [InlineData(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
+    [Test]
+    [Arguments(true, "IsSuccess = True, Value = 1", "")]
+    [Arguments(false, "IsSuccess = False", "")]
+    [Arguments(false, "IsSuccess = False, Error = \"An unknown error occurred!\"", "An unknown error occurred!")]
     public void ToString_ShouldReturnProperRepresentationForUInt128(bool success, string expected, string errorMessage)
     {
         // Arrange

--- a/tests/LightResults.Tests/ResultTests.cs
+++ b/tests/LightResults.Tests/ResultTests.cs
@@ -8,7 +8,7 @@ public sealed class ResultTests
 {
     private static readonly IError EmptyError = Error.Empty;
 
-    [Fact]
+    [Test]
     public void DefaultStruct_ShouldBeFailureResult()
     {
         // Arrange
@@ -41,7 +41,7 @@ public sealed class ResultTests
         validationError.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void IsSuccess_WhenResultIsSuccess()
     {
         // Arrange
@@ -52,7 +52,7 @@ public sealed class ResultTests
             .ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void IsFailure_WhenResultIsFailure()
     {
         // Arrange
@@ -63,7 +63,7 @@ public sealed class ResultTests
             .ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void IsFailure_WhenResultIsFailure_ShouldReturnFirstError()
     {
         // Arrange
@@ -83,7 +83,7 @@ public sealed class ResultTests
         resultError.ShouldBe(firstError);
     }
 
-    [Fact]
+    [Test]
     public void IsFailure_WhenResultIsSuccess_ShouldReturnDefaultValue()
     {
         // Arrange
@@ -97,7 +97,7 @@ public sealed class ResultTests
         resultError.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void IsFailure_WhenResultIsSuccess_ShouldReturnNullValue()
     {
         // Arrange
@@ -111,7 +111,7 @@ public sealed class ResultTests
         resultError.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void Success_ShouldCreateSuccessResult()
     {
         // Act
@@ -128,7 +128,7 @@ public sealed class ResultTests
         result.Errors.ShouldBeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void SuccessTValue_WithValue_ShouldCreateSuccessResultWithValue()
     {
         // Arrange
@@ -151,7 +151,7 @@ public sealed class ResultTests
         result.Errors.ShouldBeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void Failure_ShouldCreateFailureResultWithSingleError()
     {
         // Act
@@ -169,7 +169,7 @@ public sealed class ResultTests
         singleError.Message.ShouldBe("");
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithErrorMessage_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -190,7 +190,7 @@ public sealed class ResultTests
         singleError.Message.ShouldBe(errorMessage);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithReadOnlyCollection_ShouldPreallocateFromCount()
     {
         // Arrange
@@ -206,7 +206,7 @@ public sealed class ResultTests
         result.Errors.ShouldBe([firstError, secondError]);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithICollection_ShouldCopyUsingCopyTo()
     {
         // Arrange
@@ -222,7 +222,7 @@ public sealed class ResultTests
         result.Errors.ShouldBe([firstError, secondError]);
     }
 
-    [Fact]
+    [Test]
     public void FailureTValue_WithReadOnlyCollection_ShouldPreallocateFromCount()
     {
         // Arrange
@@ -238,7 +238,7 @@ public sealed class ResultTests
         result.Errors.ShouldBe([firstError, secondError]);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithErrorMessageAndTupleMetadata_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -265,7 +265,7 @@ public sealed class ResultTests
             .ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithErrorMessageAndKeyValuePairMetadata_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -292,7 +292,7 @@ public sealed class ResultTests
             .ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithErrorMessageAndDictionaryMetadata_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -322,7 +322,7 @@ public sealed class ResultTests
             .ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithException_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -349,7 +349,7 @@ public sealed class ResultTests
         metadata.Value.ShouldBe(exception);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithMessageAndException_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -377,7 +377,7 @@ public sealed class ResultTests
         metadata.Value.ShouldBe(exception);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithNullException_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -397,7 +397,7 @@ public sealed class ResultTests
         singleError.Metadata.Count.ShouldBe(0);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithMessageAndNullException_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -418,7 +418,7 @@ public sealed class ResultTests
         singleError.Metadata.Count.ShouldBe(0);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithErrorObject_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -439,7 +439,7 @@ public sealed class ResultTests
         singleError.ShouldBe(error);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithErrorsEnumerable_ShouldCreateFailureResultWithMultipleErrors()
     {
         // Arrange
@@ -463,7 +463,7 @@ public sealed class ResultTests
         result.Errors.ShouldBe(errors);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithCustomIterator_ShouldMaterializeErrors()
     {
         // Arrange
@@ -481,7 +481,7 @@ public sealed class ResultTests
         iterator.EnumerationCount.ShouldBe(1);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithErrorsEnumerable_ShouldReuseListInstance()
     {
         // Arrange
@@ -498,7 +498,7 @@ public sealed class ResultTests
         result.Errors.ShouldBeSameAs(errors);
     }
 
-    [Fact]
+    [Test]
     public void Failure_WithErrorsReadOnlyList_ShouldCreateFailureResultWithMultipleErrors()
     {
         // Arrange
@@ -522,7 +522,7 @@ public sealed class ResultTests
         result.Errors.ShouldBe(errors);
     }
 
-    [Fact]
+    [Test]
     public void FailureTValue_ShouldCreateFailureResultWithSingleError()
     {
         // Act
@@ -542,7 +542,7 @@ public sealed class ResultTests
         singleError.Message.ShouldBe("");
     }
 
-    [Fact]
+    [Test]
     public void FailureTValue_WithErrorMessage_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -565,7 +565,7 @@ public sealed class ResultTests
         singleError.Message.ShouldBe(errorMessage);
     }
 
-    [Fact]
+    [Test]
     public void FailureTValue_WithErrorMessageAndTupleMetadata_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -594,7 +594,7 @@ public sealed class ResultTests
             .ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
-    [Fact]
+    [Test]
     public void FailureTValue_WithErrorMessageAndKeyValuePairMetadata_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -623,7 +623,7 @@ public sealed class ResultTests
             .ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
-    [Fact]
+    [Test]
     public void FailureTValue_WithErrorMessageAndDictionaryMetadata_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -655,7 +655,7 @@ public sealed class ResultTests
             .ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
-    [Fact]
+    [Test]
     public void FailureTValue_WithException_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -682,7 +682,7 @@ public sealed class ResultTests
         metadata.Value.ShouldBe(exception);
     }
 
-    [Fact]
+    [Test]
     public void FailureTValue_WithMessageAndException_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -710,7 +710,7 @@ public sealed class ResultTests
         metadata.Value.ShouldBe(exception);
     }
 
-    [Fact]
+    [Test]
     public void FailureTValue_WithNullException_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -730,7 +730,7 @@ public sealed class ResultTests
         singleError.Metadata.Count.ShouldBe(0);
     }
 
-    [Fact]
+    [Test]
     public void FailureTValue_WithMessageAndNullException_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -751,7 +751,7 @@ public sealed class ResultTests
         singleError.Metadata.Count.ShouldBe(0);
     }
 
-    [Fact]
+    [Test]
     public void FailureTValue_WithErrorObject_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -774,7 +774,7 @@ public sealed class ResultTests
         singleError.ShouldBe(error);
     }
 
-    [Fact]
+    [Test]
     public void FailureTValue_WithErrorsEnumerable_ShouldCreateFailureResultWithMultipleErrors()
     {
         // Arrange
@@ -800,7 +800,7 @@ public sealed class ResultTests
         result.Errors.ShouldBe(errors);
     }
 
-    [Fact]
+    [Test]
     public void FailureTValue_WithCustomIterator_ShouldMaterializeErrors()
     {
         // Arrange
@@ -818,7 +818,7 @@ public sealed class ResultTests
         iterator.EnumerationCount.ShouldBe(1);
     }
 
-    [Fact]
+    [Test]
     public void HasError_WithMatchingErrorType_ShouldReturnTrue()
     {
         // Arrange
@@ -829,7 +829,7 @@ public sealed class ResultTests
             .ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void HasError_WithMatchingErrorType_ShouldOutFirstMatch()
     {
         // Arrange
@@ -849,7 +849,7 @@ public sealed class ResultTests
         error.ShouldBe(firstError);
     }
 
-    [Fact]
+    [Test]
     public void HasError_WithNonMatchingErrorType_ShouldReturnFalse()
     {
         // Arrange
@@ -860,7 +860,7 @@ public sealed class ResultTests
             .ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void HasError_WithNonMatchingErrorType_ShouldOutDefaultError()
     {
         // Arrange
@@ -874,7 +874,7 @@ public sealed class ResultTests
         error.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void HasError_WhenIsSuccess_ShouldReturnFalse()
     {
         // Arrange
@@ -885,7 +885,7 @@ public sealed class ResultTests
             .ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void HasError_WhenIsSuccess_ShouldOutDefaultError()
     {
         // Arrange
@@ -899,7 +899,7 @@ public sealed class ResultTests
         error.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void AsFailure_ShouldConvertResultToNonGenericResultWithSameErrors()
     {
         // Arrange
@@ -922,7 +922,7 @@ public sealed class ResultTests
         nonGenericResult.Errors.ShouldBe(errors);
     }
 
-    [Fact]
+    [Test]
     public void AsFailure_ShouldConvertDefaultResultToNonGenericResult()
     {
         // Arrange
@@ -942,7 +942,7 @@ public sealed class ResultTests
             .ShouldBeEquivalentTo(EmptyError);
     }
 
-    [Fact]
+    [Test]
     public void AsFailure_ShouldConvertResultToGenericResultWithSameErrors()
     {
         // Arrange
@@ -965,7 +965,7 @@ public sealed class ResultTests
         genericResult.Errors.ShouldBe(errors);
     }
 
-    [Fact]
+    [Test]
     public void AsFailure_ShouldConvertDefaultResultToGenericResult()
     {
         // Arrange
@@ -985,7 +985,7 @@ public sealed class ResultTests
             .ShouldBeEquivalentTo(EmptyError);
     }
 
-    [Fact]
+    [Test]
     public void ImplicitCast_ShouldCreateFailureResultFromError()
     {
         // Arrange
@@ -1007,7 +1007,7 @@ public sealed class ResultTests
         singleError.ShouldBe(error);
     }
 
-    [Fact]
+    [Test]
     public void Equals_Result_ShouldReturnTrueForEqualResults()
     {
         // Arrange
@@ -1019,7 +1019,7 @@ public sealed class ResultTests
             .ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void Equals_Result_ShouldReturnFalseForUnequalResults()
     {
         // Arrange
@@ -1031,7 +1031,7 @@ public sealed class ResultTests
             .ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void Equals_Object_ShouldReturnTrueForEqualResults()
     {
         // Arrange
@@ -1043,7 +1043,7 @@ public sealed class ResultTests
             .ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void Equals_Object_ShouldReturnFalseForUnequalResults()
     {
         // Arrange
@@ -1055,7 +1055,7 @@ public sealed class ResultTests
             .ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void GetHashCode_ShouldReturnSameHashCodeForEqualResults()
     {
         // Arrange
@@ -1067,7 +1067,7 @@ public sealed class ResultTests
             .ShouldBe(result2.GetHashCode());
     }
 
-    [Fact]
+    [Test]
     public void op_Equality_Result_ShouldReturnTrueForEqualResults()
     {
         // Arrange
@@ -1078,7 +1078,7 @@ public sealed class ResultTests
         (result1 == result2).ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void op_Equality_Result_ShouldReturnFalseForUnequalResults()
     {
         // Arrange
@@ -1089,7 +1089,7 @@ public sealed class ResultTests
         (result1 == result2).ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void op_Inequality_Result_ShouldReturnFalseForEqualResults()
     {
         // Arrange
@@ -1100,7 +1100,7 @@ public sealed class ResultTests
         (result1 != result2).ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void op_Inequality_Result_ShouldReturnTrueForUnequalResults()
     {
         // Arrange
@@ -1111,7 +1111,7 @@ public sealed class ResultTests
         (result1 != result2).ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void Equals_Result_DefaultResults_ShouldReturnTrue()
     {
         // Arrange
@@ -1123,7 +1123,7 @@ public sealed class ResultTests
             .ShouldBeTrue();
     }
 
-    [Fact]
+    [Test]
     public void GetHashCode_Result_DefaultResults_ShouldReturnSameHashCode()
     {
         // Arrange
@@ -1135,7 +1135,7 @@ public sealed class ResultTests
             .ShouldBe(result2.GetHashCode());
     }
 
-    [Fact]
+    [Test]
     public void Equals_Result_DefaultAndFailure_ShouldReturnFalse()
     {
         // Arrange
@@ -1147,7 +1147,7 @@ public sealed class ResultTests
             .ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void GetHashCode_Result_DefaultAndFailure_ShouldReturnDifferentHashCodes()
     {
         // Arrange
@@ -1159,7 +1159,7 @@ public sealed class ResultTests
             .ShouldNotBe(result2.GetHashCode());
     }
 
-    [Fact]
+    [Test]
     public void ToString_WhenSuccess_ShouldReturnStringRepresentation()
     {
         // Arrange
@@ -1170,9 +1170,9 @@ public sealed class ResultTests
             .ShouldBe("Result { IsSuccess = True }");
     }
 
-    [Theory]
-    [InlineData("")]
-    [InlineData("An unknown error occurred!")]
+    [Test]
+    [Arguments("")]
+    [Arguments("An unknown error occurred!")]
     public void ToString_WhenFailure_ShouldReturnStringRepresentation(string errorMessage)
     {
         // Arrange
@@ -1185,7 +1185,7 @@ public sealed class ResultTests
 
     private class ValidationError(string errorMessage) : Error(errorMessage);
 
-    [Fact]
+    [Test]
     public void InterfaceSuccess_ShouldCreateSuccessResult()
     {
         // Arrange
@@ -1209,7 +1209,7 @@ public sealed class ResultTests
         result.Errors.ShouldBeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void InterfaceFailure_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -1234,7 +1234,7 @@ public sealed class ResultTests
         singleError.Message.ShouldBe("");
     }
 
-    [Fact]
+    [Test]
     public void InterfaceFailure_WithErrorMessage_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -1260,7 +1260,7 @@ public sealed class ResultTests
         singleError.Message.ShouldBe("Sample error message");
     }
 
-    [Fact]
+    [Test]
     public void InterfaceFailure_WithErrorMessageAndTupleMetadata_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -1292,7 +1292,7 @@ public sealed class ResultTests
             .ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
-    [Fact]
+    [Test]
     public void InterfaceFailure_WithErrorMessageAndDictionaryMetadata_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -1327,7 +1327,7 @@ public sealed class ResultTests
             .ShouldBe(new KeyValuePair<string, object?>("Key", 0));
     }
 
-    [Fact]
+    [Test]
     public void InterfaceFailure_WithErrorObject_ShouldCreateFailureResultWithSingleError()
     {
         // Arrange
@@ -1353,7 +1353,7 @@ public sealed class ResultTests
         singleError.ShouldBeEquivalentTo(new Error("Sample error"));
     }
 
-    [Fact]
+    [Test]
     public void InterfaceFailure_WithErrorsEnumerable_ShouldCreateFailureResultWithMultipleErrors()
     {
         // Arrange
@@ -1383,7 +1383,7 @@ public sealed class ResultTests
         result.Errors.ShouldBeSameAs(errors);
     }
 
-    [Fact]
+    [Test]
     public void InterfaceFailure_WithErrorsReadOnlyList_ShouldCreateFailureResultWithMultipleErrors()
     {
         // Arrange

--- a/tests/LightResults.Tests/SingleItemMetadataDictionaryTests.cs
+++ b/tests/LightResults.Tests/SingleItemMetadataDictionaryTests.cs
@@ -7,7 +7,7 @@ public sealed class SingleItemMetadataDictionaryTests
     private const string StoredKey = "correlation-id";
     private const string StoredValue = "abc123";
 
-    [Fact]
+    [Test]
     public void CountAndLookup_ShouldReflectSingleStoredItem()
     {
         // Arrange
@@ -30,7 +30,7 @@ public sealed class SingleItemMetadataDictionaryTests
         missingValue.ShouldBeNull();
     }
 
-    [Fact]
+    [Test]
     public void Indexer_ShouldReturnValueOrThrow()
     {
         // Arrange
@@ -43,7 +43,7 @@ public sealed class SingleItemMetadataDictionaryTests
         Should.Throw<KeyNotFoundException>(() => _ = dictionary["missing"]);
     }
 
-    [Fact]
+    [Test]
     public void Enumerators_ShouldYieldSingleItemOnce()
     {
         // Arrange
@@ -83,7 +83,7 @@ public sealed class SingleItemMetadataDictionaryTests
             .ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void Enumerators_Reset_ShouldRestartEnumeration()
     {
         // Arrange
@@ -127,7 +127,7 @@ public sealed class SingleItemMetadataDictionaryTests
             .ShouldBeFalse();
     }
 
-    [Fact]
+    [Test]
     public void Enumerators_ResetAfterCompletion_ShouldAllowSinglePassThenStop()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- configure the test project to opt into the Microsoft.Testing.Platform runner for .NET 10
- add a repository global.json to resolve the testing platform manifest and document the new test experience
- refresh contributor guidance to note the Microsoft.Testing.Platform-backed TUnit setup

## Testing
- `dotnet test tests/LightResults.Tests/LightResults.Tests.csproj -f net10.0` *(fails: still blocked by Microsoft.Testing.Platform requiring the new dotnet test experience when invoked via the VSTest target)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692319fcfa90832898f0fb829f3eb590)